### PR TITLE
Used quoted attributes for <img>

### DIFF
--- a/rst2pdf/math_directive.py
+++ b/rst2pdf/math_directive.py
@@ -100,7 +100,7 @@ class HandleMath(basenodehandler.NodeHandler, math_node):
         descent = mf.descent()
         img = mf.genImage()
         client.to_unlink.append(img)
-        return '<img src="%s" width=%f height=%f valign=%f/>' % (
+        return '<img src="%s" width="%f" height="%f" valign="%f"/>' % (
             img, w, h, -descent)
 
 class HandleEq(basenodehandler.NodeHandler, eq_node):

--- a/rst2pdf/sphinxnodes.py
+++ b/rst2pdf/sphinxnodes.py
@@ -194,7 +194,7 @@ class HandleSphinxMath(SphinxHandler, mathbase.math, mathbase.displaymath):
         descent = mf.descent()
         img = mf.genImage()
         client.to_unlink.append(img)
-        return '<img src="%s" width=%f height=%f valign=%f/>' % (
+        return '<img src="%s" width="%f" height="%f" valign="%f"/>' % (
             img, w, h, -descent)
 
 class HandleSphinxEq(SphinxHandler, mathbase.eqref):


### PR DESCRIPTION
Added double quotes to all unquoted attribute values for `<img>` tags. This should solve issue https://github.com/rst2pdf/rst2pdf/issues/517.
