### PR TITLE
Use relative path above others

### DIFF
--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -999,6 +999,9 @@ class FancyPage(PageTemplate):
         info = self.image_cache.get(uri)
         if info is None:
             fname, _, _ = MyImage.split_uri(uri)
+            rel_fname = os.path.join(os.getcwd(), fname)
+            if os.path.exists(rel_fname):
+                fname = rel_fname
             if not os.path.exists(fname):
                 del self.template[which]
                 log.error("Missing %s image file: %s", which, uri)

--- a/rst2pdf/image.py
+++ b/rst2pdf/image.py
@@ -281,7 +281,11 @@ class MyImage (Flowable):
 
         uri = str(node.get("uri"))
         if uri.split("://")[0].lower() not in ('http','ftp','https'):
-            uri = os.path.join(client.basedir,uri)
+            rel_uri = os.path.join(os.getcwd(), uri)
+            if os.path.exists(rel_uri):
+                uri = rel_uri
+            else:
+                uri = os.path.join(client.basedir, uri)
         else:
             uri, _ = urllib.urlretrieve(uri)
             client.to_unlink.append(uri)


### PR DESCRIPTION
The behavior being changed here is that images will reference relative images, but
when the `MyImage.size_for_node` method is called, it references the
`self.client.basedir`, which is not going to be the same as `os.getcwd()` given
a path structure like:

```
images/background.pdf
files/test.rst
```

This works for my use case, which uses a path similar to the above example. Any guidance on other side effects this change might induce would be helpful. I ran tests, which were already failing, but I've introduced no new bugs with this PR at least.
