### PR TITLE
[FIX] Python2-only except clauses

### DIFF
--- a/gui/codeeditor.py
+++ b/gui/codeeditor.py
@@ -18,39 +18,39 @@ class LineNumberArea(QtGui.QWidget):
 
 
 class CodeEditor(QtGui.QPlainTextEdit):
-    
+
     def __init__(self,parent=None):
         QtGui.QPlainTextEdit.__init__(self,parent)
         self.lineNumberArea = LineNumberArea (self)
-        self.connect(self, QtCore.SIGNAL("blockCountChanged(int)"), 
+        self.connect(self, QtCore.SIGNAL("blockCountChanged(int)"),
                      self.updateLineNumberAreaWidth)
-            
-        self.connect(self, QtCore.SIGNAL("updateRequest(const QRect &, int)"), 
+
+        self.connect(self, QtCore.SIGNAL("updateRequest(const QRect &, int)"),
                      self.updateLineNumberArea)
-                
-        self.connect(self, QtCore.SIGNAL("cursorPositionChanged()"), 
+
+        self.connect(self, QtCore.SIGNAL("cursorPositionChanged()"),
                      self.highlightCurrentLine)
 
         self.updateLineNumberAreaWidth(0)
         self.errorPos=None
         self.highlightCurrentLine()
-        
+
     def lineNumberAreaPaintEvent(self, event):
         painter=QtGui.QPainter(self.lineNumberArea)
         painter.fillRect(event.rect(), QtCore.Qt.lightGray)
-        
+
         block = self.firstVisibleBlock()
         blockNumber = block.blockNumber();
         top = int(self.blockBoundingGeometry(block).translated(self.contentOffset()).top())
         bottom = top + int(self.blockBoundingRect(block).height())
-        
+
         while block.isValid() and top <= event.rect().bottom():
-            
-            
+
+
             if block.isVisible() and bottom >= event.rect().top():
                 number = str(blockNumber + 1)
                 painter.setPen(QtCore.Qt.black)
-                painter.drawText(0, top, self.lineNumberArea.width(), 
+                painter.drawText(0, top, self.lineNumberArea.width(),
                     self.fontMetrics().height(),
                     QtCore.Qt.AlignRight, number)
 
@@ -58,7 +58,7 @@ class CodeEditor(QtGui.QPlainTextEdit):
             top = bottom
             bottom = top + int(self.blockBoundingRect(block).height())
             blockNumber+=1
-        
+
     def lineNumberAreaWidth(self):
         digits = 1
         _max = max (1, self.blockCount())
@@ -67,17 +67,17 @@ class CodeEditor(QtGui.QPlainTextEdit):
             digits+=1
         space = 5 + self.fontMetrics().width('9') * digits
         return space
-    
+
     def updateLineNumberAreaWidth(self, newBlockCount):
         self.setViewportMargins(self.lineNumberAreaWidth(), 0, 0, 0)
 
 
     def updateLineNumberArea(self, rect, dy):
-        
+
         if dy:
             self.lineNumberArea.scroll(0, dy);
         else:
-            self.lineNumberArea.update(0, rect.y(), 
+            self.lineNumberArea.update(0, rect.y(),
                 self.lineNumberArea.width(), rect.height())
 
         if rect.contains(self.viewport().rect()):
@@ -86,19 +86,19 @@ class CodeEditor(QtGui.QPlainTextEdit):
     def resizeEvent(self, e):
         QtGui.QPlainTextEdit.resizeEvent(self,e)
         self.cr = self.contentsRect()
-        self.lineNumberArea.setGeometry(self.cr.left(), 
-                                        self.cr.top(), 
-                                        self.lineNumberAreaWidth(), 
+        self.lineNumberArea.setGeometry(self.cr.left(),
+                                        self.cr.top(),
+                                        self.lineNumberAreaWidth(),
                                         self.cr.height())
-                                        
+
     def highlightError(self,pos):
         self.errorPos=pos
         self.highlightCurrentLine()
 
-             
-    def highlightCurrentLine(self):         
+
+    def highlightCurrentLine(self):
         extraSelections=[]
-        if not self.isReadOnly():             
+        if not self.isReadOnly():
             selection = QtGui.QTextEdit.ExtraSelection()
             lineColor = QtGui.QColor(QtCore.Qt.yellow).lighter(160)
             selection.format.setBackground(lineColor)
@@ -106,7 +106,7 @@ class CodeEditor(QtGui.QPlainTextEdit):
             selection.cursor = self.textCursor()
             selection.cursor.clearSelection()
             extraSelections.append(selection)
-            
+
             if self.errorPos is not None:
                 errorSel = QtGui.QTextEdit.ExtraSelection()
                 lineColor = QtGui.QColor(QtCore.Qt.red).lighter(160)
@@ -120,13 +120,13 @@ class CodeEditor(QtGui.QPlainTextEdit):
         self.setExtraSelections(extraSelections)
 
 if __name__ == "__main__":
-    
+
     try:
         import json
     except ImportError:
         import simplejson as json
     from highlighter import Highlighter
-    
+
     app = QtGui.QApplication(sys.argv)
 
     js = CodeEditor()
@@ -141,7 +141,8 @@ if __name__ == "__main__":
         pos=None
         try:
             json.loads(style)
-        except ValueError, e:
+        except ValueError:
+            _, e, _ = sys.exc_info()
             s=str(e)
             print s
             if s == 'No JSON object could be decoded':
@@ -152,7 +153,7 @@ if __name__ == "__main__":
                 pos=int(s.split(' ')[-3])
             else:
                 print 'UNKNOWN ERROR'
-                
+
         # This makes a red bar appear in the line
         # containing position pos
         js.highlightError(pos)

--- a/gui/main.py
+++ b/gui/main.py
@@ -96,7 +96,8 @@ def renderQueue(render_queue, pdf_queue, doctree_queue):
                     settings_overrides={'warning_stream':warnings})
                 doctree_queue.put([doctree,warnings.getvalue()])
                 pdf_queue.put(render(doctree, preview))
-            except Exception, e:
+            except Exception:
+                _, e, _ = sys.exc_info()
                 # Don't crash ever ;-)
                 print e
                 pass
@@ -498,7 +499,8 @@ class Main(QtGui.QMainWindow):
         try:
             json.loads(style)
             self.statusMessage.setText('')
-        except ValueError, e:
+        except ValueError:
+            _, e, _ = sys.exc_info()
             s=str(e)
             if s == 'No JSON object could be decoded':
                 pos=0

--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -545,7 +545,7 @@ class RstToPdf(object):
                 return
         else:
             self.doctree = doctree
-            
+
         if self.numbered_links:
             # Transform all links to sections so they show numbers
             from sectnumlinks import SectNumFolder, SectRefExpander
@@ -557,7 +557,7 @@ class RstToPdf(object):
             from docutils.transforms.universal import StripClassesAndElements
             sce = StripClassesAndElements(self.doctree)
             sce.apply()
-            
+
         elements = self.gen_elements(self.doctree)
 
         # Find cover template, save it in cover_file
@@ -692,7 +692,8 @@ class RstToPdf(object):
 
 
                 break
-            except ValueError, v:
+            except ValueError:
+                _, v, _ = sys.exc_info()
                 # FIXME: cross-document links come through here, which means
                 # an extra pass per cross-document reference. Which sucks.
                 #if v.args and str(v.args[0]).startswith('format not resolved'):
@@ -1030,8 +1031,8 @@ class FancyPage(PageTemplate):
         bg.drawOn(canv, x, y)
 
     def is_left(self, page_num):
-        """Default behavior is that the first page is on the left.   
-           
+        """Default behavior is that the first page is on the left.
+
            If the user has --first_page_on_right, the calculation is reversed.
         """
         val = page_num % 2 == 1
@@ -1332,7 +1333,7 @@ def parse_commandline():
     parser.add_option('--use-numbered-links', action='store_true', default=def_numbered_links,
         help='When using numbered sections, adds the numbers to all links referring to the section headers. Default: %s'%def_numbered_links,
         dest='numbered_links')
-        
+
     parser.add_option('--strip-elements-with-class', action='append', dest='strip_elements_with_classes',
         metavar='CLASS', help='Remove elements with this CLASS from the output. Can be used multiple times.')
 
@@ -1400,7 +1401,8 @@ def main(_args=None):
         options.basedir=os.path.dirname(os.path.abspath(filename))
         try:
             infile = open(filename)
-        except IOError, e:
+        except IOError:
+            _, e, _ = sys.exc_info()
             log.error(e)
             sys.exit(1)
     options.infile = infile
@@ -1574,11 +1576,13 @@ def add_extensions(options):
         try:
             try:
                 module = __import__(firstname, globals(), locals())
-            except ImportError, e:
+            except ImportError:
+                _, e, _ = sys.exc_info()
                 if firstname != str(e).split()[-1]:
                     raise
                 module = __import__(modname, globals(), locals())
-        except ImportError, e:
+        except ImportError:
+            _, e, _ = sys.exc_info()
             if str(e).split()[-1] not in [firstname, modname]:
                 raise
             raise SystemExit('\nError: Could not find module %s '

--- a/rst2pdf/extensions/inkscape_r2p.py
+++ b/rst2pdf/extensions/inkscape_r2p.py
@@ -53,7 +53,8 @@ class InkscapeImage(VectorPdf):
             cmd = [progname, os.path.abspath(filename), '-A', pdffname]
             try:
                 subprocess.call(cmd)
-            except OSError, e:
+            except OSError:
+                _, e, _ = sys.exc_info()
                 log.error("Failed to run command: %s", ' '.join(cmd))
                 raise
             self.load_xobj((client, pdffname))
@@ -76,7 +77,8 @@ class InkscapeImage(VectorPdf):
             try:
                 subprocess.call(cmd)
                 return pngfname
-            except OSError, e:
+            except OSError:
+                _, e, _ = sys.exc_info()
                 log.error("Failed to run command: %s", ' '.join(cmd))
                 raise
         return None

--- a/rst2pdf/extensions/plantuml.py
+++ b/rst2pdf/extensions/plantuml.py
@@ -65,7 +65,8 @@ class UMLHandler(genelements.NodeHandler, plantuml):
         try:
             p = subprocess.Popen(args.split(), stdout=tfile,
                                  stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-        except OSError, err:
+        except OSError:
+            _, err, _ = sys.exc_info()
             if err.errno != errno.ENOENT:
                 raise
             raise PlantUmlError('plantuml command %r cannot be run'
@@ -73,7 +74,7 @@ class UMLHandler(genelements.NodeHandler, plantuml):
         serr = p.communicate(node['uml'].encode('utf-8'))[1]
         if p.returncode != 0:
             raise PlantUmlError('error while running plantuml\n\n' + serr)
-        
+
         # Add Image node with the right image
         return [MyImage(tfile.name, client=client)]
 

--- a/rst2pdf/extensions/preprocess_r2p.py
+++ b/rst2pdf/extensions/preprocess_r2p.py
@@ -301,9 +301,10 @@ class Preprocess(object):
             log.error("Empty .. style:: block found")
         try:
             styles = rson_loads(mystyles)
-        except ValueError, e: # Error parsing the JSON data
-                log.critical('Error parsing stylesheet "%s": %s'%\
-                    (mystyles, str(e)))
+        except ValueError: # Error parsing the JSON data
+            _, e, _ = sys.exc_info()
+            log.critical('Error parsing stylesheet "%s": %s'%\
+                (mystyles, str(e)))
         else:
             self.styles.setdefault('styles', {}).update(styles)
 

--- a/rst2pdf/findfonts.py
+++ b/rst2pdf/findfonts.py
@@ -43,7 +43,7 @@ def loadFonts():
     """
     Search the system and build lists of available fonts.
     """
-    
+
     if not afmList and not pfbList and not ttfList:
         # Find all ".afm" and ".pfb" files files
         def findFontFiles(_, folder, names):
@@ -65,13 +65,13 @@ def loadFonts():
                 font = TTFontFile(ttf)
             except TTFError:
                 continue
-            
+
             #print ttf, font.name, font.fullName, font.styleName, font.familyName
             family=font.familyName.lower()
             fontName=font.name
             baseName = os.path.basename(ttf)[:-4]
             fullName=font.fullName
-            
+
             fonts[fontName.lower()] = (ttf, ttf, family)
             fonts[fullName.lower()] = (ttf, ttf, family)
             fonts[fullName.lower().replace('italic','oblique')] = (ttf, ttf, family)
@@ -91,7 +91,7 @@ def loadFonts():
             # weights? We get a random one.
             else:
                 families[family][0] = fontName
-                
+
         # Now we have full afm and pbf lists, process the
         # afm list to figure out family name, weight and if
         # it's italic or not, as well as where the
@@ -227,7 +227,8 @@ def findTTFont(fname):
                 fontdir += u"\\Fonts"
                 fontkey.Close()
                 return fontdir + "\\" + fname
-            except WindowsError, err:
+            except WindowsError:
+                _, err, _ = sys.exc_info()
                 fontkey.Close()
                 return None
 
@@ -350,13 +351,13 @@ def guessFont(fname):
 
     else:
         family, mod = fname.rsplit('-', 1)
-        
+
     mod = mod.lower()
     if "oblique" in mod or "italic" in mod:
         italic = 1
     if "bold" in mod:
         bold = 1
-     
+
     if bold+italic == 0: #Not really a modifier
         return fname, 0
     return family, bold + 2*italic

--- a/rst2pdf/languages.py
+++ b/rst2pdf/languages.py
@@ -13,7 +13,8 @@ def get_language_silent(lang):
     """Docutils get_language() with patches for older versions."""
     try:
         return get_language(lang)
-    except TypeError, err: # Docutils 0.8.1
+    except TypeError: # Docutils 0.8.1
+        _, err, _ = sys.exc_info()
         if 'get_language() takes exactly 2 arguments' in str(err):
             class SilentReporter(object):
                 def warning(self, msg):

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -126,7 +126,8 @@ class PDFBuilder(Builder):
                 self.info("writing " + targetname + "... ", nonl=1)
                 docwriter.write(doctree, destination)
                 self.info("done")
-            except Exception, e:
+            except Exception:
+                _, e, _ = sys.exc_info()
                 log.error(str(e))
                 print_exc()
                 self.info(red("FAILED"))
@@ -845,7 +846,8 @@ def init_math(app):
         try:
             # Sphinx 0.6.3
             from sphinx.ext.mathbase import setup as mathbase_setup
-        except ImportError, e:
+        except ImportError:
+            _, e, _ = sys.exc_info()
             log.error('Error importing sphinx math extension: %s', e)
 
     class MathExtError(SphinxError):

--- a/rst2pdf/sphinxnodes.py
+++ b/rst2pdf/sphinxnodes.py
@@ -229,7 +229,8 @@ try:
                     # Something went very wrong with graphviz, and
                     # sphinx should have given an error already
                     return []
-            except sphinx.ext.graphviz.GraphvizError, exc:
+            except sphinx.ext.graphviz.GraphvizError:
+                _, exc, _ = sys.exc_info()
                 log.error('dot code %r: ' % node['code'] + str(exc))
                 return [Paragraph(node['code'],client.styles['code'])]
             return [MyImage(filename=outfn, client=client)]

--- a/rst2pdf/styles.py
+++ b/rst2pdf/styles.py
@@ -298,7 +298,8 @@ class StyleSheet(object):
                         bold = pdfmetrics.EmbeddedType1Face(*font[3])
                         bolditalic = pdfmetrics.EmbeddedType1Face(*font[4])
 
-                except Exception, e:
+                except Exception:
+                    _, e, _ = sys.exc_info()
                     try:
                         if isinstance(font, list):
                             fname = font[0]
@@ -308,7 +309,8 @@ class StyleSheet(object):
                             os.path.splitext(fname)[0], str(e))
                         log.error("Registering %s as Helvetica alias", fname)
                         self.fontsAlias[fname] = 'Helvetica'
-                    except Exception, e:
+                    except Exception:
+                        _, e, _ = sys.exc_info()
                         log.critical("Error processing font %s: %s",
                             fname, str(e))
                         continue
@@ -591,10 +593,12 @@ class StyleSheet(object):
             if fname:
                 try:
                     return rson_loads(open(fname).read())
-                except ValueError, e: # Error parsing the JSON data
+                except ValueError: # Error parsing the JSON data
+                    _, e, _ = sys.exc_info()
                     log.critical('Error parsing stylesheet "%s": %s'%\
                         (fname, str(e)))
-                except IOError, e: #Error opening the ssheet
+                except IOError: #Error opening the ssheet
+                    _, e, _ = sys.exc_info()
                     log.critical('Error opening stylesheet "%s": %s'%\
                         (fname, str(e)))
 

--- a/rst2pdf/tenjin.py
+++ b/rst2pdf/tenjin.py
@@ -57,12 +57,14 @@ try:
     import fcntl
     def _lock_file(file, content):
         fcntl.flock(file.fileno(), fcntl.LOCK_EX)
-except ImportError, ex:
+except ImportError:
+    _, ex, _ = sys.exc_info()
     try:
         import msvcrt
         def _lock_file(file, content):
             msvcrt.locking(file.fileno(), msvcrt.LK_LOCK, len(content))
-    except ImportError, ex:
+    except ImportError:
+        _, ex, _ = sys.exc_info()
         def _lock_file(file, content):
             pass
 

--- a/rst2pdf/tests/execmgr.py
+++ b/rst2pdf/tests/execmgr.py
@@ -44,7 +44,7 @@ class BaseExec(object):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 preexec_fn=None,   # Callable object in child process
-                close_fds=False,   
+                close_fds=False,
                 shell=False,
                 cwd=None,
                 env=None,
@@ -80,7 +80,8 @@ class BaseExec(object):
                 sys.stdout.flush()
                 print >> sys.stderr, traceback.format_exc()
                 sys.stderr.write(chr(1))
-            except SystemExit, s:
+            except SystemExit:
+                _, s, _ = sys.exc_info()
                 sys.stdout.flush()
                 code = s.code
                 try:


### PR DESCRIPTION
The ```except Exception, val``` syntax is not supported in python 3. A small bite in #537 