### PR TITLE
Images, generated by some Sphinx extensions, are found

### DIFF
--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -141,6 +141,7 @@ class RstToPdf(object):
                  show_frame=False,
                  highlightlang='python', # this one is only used by Sphinx
                  basedir=os.getcwd(),
+                 outdir=os.getcwd(),
                  splittables=False,
                  blank_first_page=False,
                  first_page_on_right=False,
@@ -159,6 +160,7 @@ class RstToPdf(object):
         self.blank_first_page=blank_first_page
         self.splittables=splittables
         self.basedir=basedir
+        self.outdir=outdir
         self.language, self.docutils_language = get_language_available(
             language)[:2]
         self.doc_title = ""

--- a/rst2pdf/genpdftext.py
+++ b/rst2pdf/genpdftext.py
@@ -145,6 +145,11 @@ class HandleImage(NodeHandler, docutils.nodes.image):
         uri = str(node.get("uri"))
         if uri.split("://")[0].lower() not in ('http','ftp','https'):
             imgname = os.path.join(client.basedir,uri)
+            # Sphinx extensions 'normally' put generated images in outdir,
+            # and insert relevant (to outdir) image file name to the doc node.
+            # Here, we have no idea which is the case. Try both.
+            if not os.path.isfile(imgname):
+                imgname = os.path.join(client.outdir, uri)
         else:
             imgname = uri
         try:

--- a/rst2pdf/image.py
+++ b/rst2pdf/image.py
@@ -281,17 +281,17 @@ class MyImage (Flowable):
 
         uri = str(node.get("uri"))
         if uri.split("://")[0].lower() not in ('http','ftp','https'):
-            uri = os.path.join(client.basedir,uri)
+            imgname = os.path.join(client.basedir,uri)
+            if not os.path.isfile(imgname):
+                imgname = os.path.join(client.outdir, uri)
+                if not os.path.isfile(imgname):
+                    imgname = missing
+
         else:
-            uri, _ = urllib.urlretrieve(uri)
-            client.to_unlink.append(uri)
+            imgname, _ = urllib.urlretrieve(uri)
+            client.to_unlink.append(imgname)
 
-        srcinfo = client, uri
-        # Extract all the information from the URI
-        imgname, extension, options = self.split_uri(uri)
-
-        if not os.path.isfile(imgname):
-            imgname = missing
+        srcinfo = client, imgname
 
         scale = float(node.get('scale', 100))/100
         size_known = False

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -610,6 +610,7 @@ class PDFWriter(writers.Writer):
                  splittables=self.splittables,
                  style_path=self.style_path,
                  basedir=self.srcdir,
+                 outdir=self.builder.outdir,
                  def_dpi=self.default_dpi,
                  real_footnotes=self.real_footnotes,
                  numbered_links=self.use_numbered_links,


### PR DESCRIPTION
Closes #578.

Some Sphinx extensions which generate images save them to Sphinx `output` directory, and insert the file path relative to this directory into the doctree node representing the image. This seems to be typical (and natural) behavior. Sphinx own builders pick the images from there.

But `rst2pdf` assumes the paths to be relative to the **source document directory**. Thus, images generated by Sphinx extensions, are not found. One extension, `sphinxcontrib-plantuml`, even [fixed this](https://bitbucket.org/birkenfeld/sphinx-contrib/commits/9a4d64cef2805f28f5e9fa7208ab65d82fe39130) by checking, whether the builder is rst2pdf, and inserting absolute file paths for images then.

If an image is not found the source directory, it is searched for in the Sphinx output directory.
