### PR TITLE
fix(createpdf.main): release input file handler

### DIFF
--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -1504,7 +1504,8 @@ def main(_args=None):
                     source_path=options.infile.name,
                     output=options.outfile,
                     compressed=options.compressed)
-
+    options.infile.close()
+                    
 # Ugly hack that fixes Issue 335
 reportlab.lib.utils.ImageReader.__deepcopy__ = lambda self,*x: copy(self)
 


### PR DESCRIPTION
Hello and thanks for rst2pdf,

I'm using rst2pdf from python code (a fabric task) and using a temporary file as an input file to add substitution variables. The problem I have is that `rst2pdf.createpdf.main` does not release the handler to this input file, and therefore my code cannot delete the temporary file after the pdf has been created. As there is no way to retrieve that file handler the only way to solve that is to release it from within `createpdf.main`.

Adding `options.infile.close()` at the end of `rst2pdf.createpdf.main` solves the issue.

Thanks again!
