### PR TITLE
[ENH] Add circle.yml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ bin/
 develop-eggs/
 eggs/
 .coverage
+rst2pdf/tests/input/*/_build
+rst2pdf/tests/output/*.pdf
+rst2pdf/tests/output/*.log
+rst2pdf/tests/input/*.build_temp

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 before_install:
  - pip install -r requirements.txt
- - pip install -e .[tests,sphinx,hyphenation,images,pdfimages,pdfimages2,svgsupport,aafiguresupport,rawhtmlsupport]
+ - pip install -e .[tests,sphinx,hyphenation,images,pdfimages,pdfimages2,svgsupport,aafiguresupport,mathsupport,rawhtmlsupport]
  - python bootstrap.py
  - ./bin/buildout
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 before_install:
  - pip install -r requirements.txt
- - python setup.py install
+ - pip install -e .[tests,sphinx,hyphenation,images,pdfimages,pdfimages2,svgsupport,aafiguresupport,rawhtmlsupport]
  - python bootstrap.py
  - ./bin/buildout
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
+cache:
+- apt
+
 language: python
 python:
  - 2.7
  - 3.5
 
 before_install:
+ - sudo apt-get -y update
+ - sudo apt-get install -y inkscape imagemagick
  - pip install -r requirements.txt
  - pip install -e .[tests,sphinx,hyphenation,images,pdfimages,pdfimages2,svgsupport,aafiguresupport,mathsupport,rawhtmlsupport]
  - python bootstrap.py

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
     - mkdir -p ${CIRCLE_TEST_REPORTS}/nose ~/pdf/
     - pip install -r requirements.txt
   override:
-    - pip install -e .[tests,sphinx,hyphenation,images,pdfimages,pdfimages2,svgsupport,aafiguresupport,rawhtmlsupport]
+    - pip install -e .[tests,sphinx,hyphenation,images,pdfimages,pdfimages2,svgsupport,aafiguresupport,mathsupport,rawhtmlsupport]
     - python bootstrap.py
     - ./bin/buildout
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,11 @@
+
 dependencies:
+  cache_directories:
+    - "~/.apt-cache"
   pre:
+    # Let CircleCI cache the apt archive
+    - mkdir -p ~/.apt-cache/partial && sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives
+    - sudo apt-get -y update && sudo apt-get install -y inkscape
     - mkdir -p ${CIRCLE_TEST_REPORTS}/nose ~/pdf/
     - pip install -r requirements.txt
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ test:
   override:
     - nosetests -i regulartest -i sphinxtest --with-xunit --xunit-file=${CIRCLE_TEST_REPORTS}/nose/${CIRCLE_PROJECT_REPONAME}.xml
   post:
-    - ./parselogs.py > ~/log.txt
+    - ./rst2pdf/tests/parselogs.py > ~/log.txt
 general:
   artifacts:
     - "~/rst2pdf/rst2pdf/tests/output/"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+dependencies:
+  pre:
+    - mkdir -p ${CIRCLE_TEST_REPORTS}/nose
+    - pip install -r requirements.txt
+  override:
+    - pip install -e .
+    - python bootstrap.py
+    - ./bin/buildout
+test:
+  override:
+    - nosetests -i regulartest -i sphinxtest --with-xunit --xunit-file=${CIRCLE_TEST_REPORTS}/nose/${CIRCLE_PROJECT_REPONAME}.xml
+general:
+  artifacts:
+    - "~/rst2pdf/rst2pdf/tests/output/"

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,9 @@ dependencies:
 test:
   override:
     - nosetests -i regulartest -i sphinxtest --with-xunit --xunit-file=${CIRCLE_TEST_REPORTS}/nose/${CIRCLE_PROJECT_REPONAME}.xml
+  post:
+    - ./parselogs.py > ~/log.txt
 general:
   artifacts:
     - "~/rst2pdf/rst2pdf/tests/output/"
+    - "~/log.txt"

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ dependencies:
     - mkdir -p ${CIRCLE_TEST_REPORTS}/nose ~/pdf/
     - pip install -r requirements.txt
   override:
-    - pip install -e .
+    - pip install -e .[tests,sphinx,hyphenation,images,pdfimages,pdfimages2,svgsupport,aafiguresupport,rawhtmlsupport]
     - python bootstrap.py
     - ./bin/buildout
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   pre:
-    - mkdir -p ${CIRCLE_TEST_REPORTS}/nose
+    - mkdir -p ${CIRCLE_TEST_REPORTS}/nose ~/pdf/
     - pip install -r requirements.txt
   override:
     - pip install -e .
@@ -10,8 +10,11 @@ test:
   override:
     - nosetests -i regulartest -i sphinxtest --with-xunit --xunit-file=${CIRCLE_TEST_REPORTS}/nose/${CIRCLE_PROJECT_REPONAME}.xml
   post:
-    - ./rst2pdf/tests/parselogs.py > ~/log.txt
+#    - ./rst2pdf/tests/parselogs.py > ~/log.txt
+    - cat ./rst2pdf/tests/output/*.log >> ~/log.txt
+    - mv ./rst2pdf/tests/output/*.pdf ~/pdf/
 general:
   artifacts:
-    - "~/rst2pdf/rst2pdf/tests/output/"
+    - "~/pdf/"
     - "~/log.txt"
+    - "~/rst2pdf/rst2pdf/tests/output/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools>=18.5
 future
 pyhyphen
 nose

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ long_description = (
     )
 
 install_requires = [
-        'setuptools',
+        'setuptools>=18.5',
         'docutils',
         'reportlab>=2.4',
         'Pygments',
@@ -58,7 +58,7 @@ pdfimages2_require = ['pyPdf','SWFTools']
 svgsupport_require = ['svg2rlg']
 aafiguresupport_require = ['aafigure>=0.4']
 mathsupport_require = ['matplotlib']
-rawhtmlsupport_require = ['xhtml2pdf']
+rawhtmlsupport_require = ['setuptools>=18.5', 'xhtml2pdf']
 
 setup(
     name="rst2pdf",


### PR DESCRIPTION
This PR adds a circle.yml file for this continuous integration service. Closes #589.

The plus of CircleCI is that one can easily access the artifacts of the build, for instance: https://circleci.com/gh/oesteban/rst2pdf/5#artifacts/containers/0.

Therefore, it is really easy to check out the pdfs that were generated during the tests, for instance: https://5-63491835-gh.circle-artifacts.com/0//home/ubuntu/rst2pdf/rst2pdf/tests/output/test_csv_table.pdf
