### PR TITLE
Fix configparser use for Python2

### DIFF
--- a/rst2pdf/config.py
+++ b/rst2pdf/config.py
@@ -8,8 +8,7 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-
-import configparser
+from configparser import ConfigParser
 import os
 from rst2pdf.rson import loads
 
@@ -32,7 +31,7 @@ class ConfigError(Exception):
         self.modulename = modulename
         self.msg = msg
 
-conf = configparser.SafeConfigParser()
+conf = ConfigParser.SafeConfigParser()
 
 def parseConfig(extracf=None):
     global conf


### PR DESCRIPTION

http://python-future.org/compatible_idioms.html#configparser

```python
# Python 2 only:
from ConfigParser import ConfigParser

# Python 2 and 3 (after ``pip install configparser``):
from configparser import ConfigParser
```

Note that, as of v0.16.0, python-future no longer includes an alias for the configparser module because a full backport exists (see https://pypi.python.org/pypi/configparser).