### PR TITLE
Create document index also with Sphinx >= 1.4

### DIFF
--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -382,7 +382,8 @@ def genindex_nodes(genindexentries):
     for key, entries in genindexentries:
         #from pudb import set_trace; set_trace()
         output.append('.. cssclass:: heading4\n\n%s\n\n'%key) # initial
-        for entryname, (links, subitems) in entries:
+        for entryname, entryvalue in entries:
+            links, subitems = entryvalue[0:2]
             if links:
                 output.append('`%s <#%s>`_'%(entryname,nodes.make_id(links[0][1])))
                 for i,link in enumerate(links[1:]):


### PR DESCRIPTION
Cherry pick of the fix for #566 that is in PR #576 by @KonstantinShemyak

Sphinx changed internal representation of BuildEnvironment.indexentries in
version 1.4 (commit e6a5a3a92e938fcd75866b4227db9e0524d58f7c) by adding one
more value to the list. Update pdfbuilder accordingly to work with both
pre-1.4 and later Sphinx versions.

Closes issue #566.