### PR TITLE
Support :hl_lines: code directive

### DIFF
--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -928,6 +928,19 @@ You can use the ``linenos`` option to display line numbers:
    def myFun(x,y):
        print x+y
 
+You can use the ``hl_lines`` option to emphasize certain lines by dimming the
+other lines. This parameter takes a space separated list of line numbers. The
+other lines are then styled with the class ``pygments_diml`` that defaults to
+gray. e.g. to highlight ``print "line a"`` and ``print "line b"``:
+
+.. code-block:: python
+   :hl_lines: 2 3
+
+   def myFun(x,y):
+       print "line a"
+       print "line b"
+       print "line c"
+
 Rst2pdf includes several stylesheets for highlighting code:
 
 * autumn

--- a/rst2pdf/styles/styles.style
+++ b/rst2pdf/styles/styles.style
@@ -495,6 +495,7 @@
       parent: bodytext
       alignment: center
 
+    pygments-diml: {parent: code, textColor: #aaaaaa}
     pygments-n: parent: code
     pygments-nx: parent: code
     pygments-p: parent: code

--- a/rst2pdf/tests/input/test_hl_lines.txt
+++ b/rst2pdf/tests/input/test_hl_lines.txt
@@ -1,0 +1,20 @@
+Highlight lines
+---------------
+
+The following code snippet should dim all lines that are not marked with
+``hl_lines`, and so the effect is to highlight the selected lines
+
+.. code-block:: python
+   :linenos:
+   :hl_lines: 3 5 6
+
+    def f():
+        a = 1
+        b = 2
+        c = 3
+        d = 4
+        e = 5
+        f = 6
+        g = 7
+
+

--- a/rst2pdf/tests/input/test_hl_lines.txt
+++ b/rst2pdf/tests/input/test_hl_lines.txt
@@ -2,7 +2,7 @@ Highlight lines
 ---------------
 
 The following code snippet should dim all lines that are not marked with
-``hl_lines`, and so the effect is to highlight the selected lines
+``hl_lines``, and so the effect is to highlight the selected lines
 
 .. code-block:: python
    :linenos:

--- a/rst2pdf/tests/md5/test_hl_lines.json
+++ b/rst2pdf/tests/md5/test_hl_lines.json
@@ -1,0 +1,9 @@
+bad_md5 = [
+        'sentinel'
+]
+
+good_md5 = [
+        '10627bb118fd2472712a7ca3535cb8a8',
+        'sentinel'
+]
+

--- a/rst2pdf/tests/md5/test_hl_lines.json
+++ b/rst2pdf/tests/md5/test_hl_lines.json
@@ -3,7 +3,7 @@ bad_md5 = [
 ]
 
 good_md5 = [
-        '10627bb118fd2472712a7ca3535cb8a8',
+        '39183aa34a9651513e74efc53ea71ea0',
         'sentinel'
 ]
 

--- a/rst2pdf/tests/reference/test_hl_lines.pdf
+++ b/rst2pdf/tests/reference/test_hl_lines.pdf
@@ -1,0 +1,231 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Outlines 10 0 R /PageLabels 11 0 R /PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (Highlight lines) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 1 /Kids [ 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Length 4444
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 741.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 4 Tm /F2 20 Tf 24 TL 166.0449 0 Td (Highlight lines) Tj T* -166.0449 0 Td ET
+Q
+Q
+q
+1 0 0 1 62.69291 707.0236 cm
+q
+BT 1 0 0 1 0 14 Tm .147356 Tw 12 TL /F1 10 Tf 0 0 0 rg (The following code snippet should dim all lines that are not marked with ) Tj /F3 10 Tf 0 0 0 rg (hl_lines) Tj /F1 10 Tf 0 0 0 rg (, and so the effect is to) Tj T* 0 Tw (highlight the selected lines) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 589.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 108 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 84 6 12 re f*
+.960784 .960784 .862745 rg
+n 12 84 0 12 re f*
+.960784 .960784 .862745 rg
+n 18 84 18 12 re f*
+.960784 .960784 .862745 rg
+n 36 84 0 12 re f*
+.960784 .960784 .862745 rg
+n 42 84 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 84 18 12 re f*
+.960784 .960784 .862745 rg
+n 66 84 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 72 6 12 re f*
+.960784 .960784 .862745 rg
+n 42 72 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 54 72 6 12 re f*
+.960784 .960784 .862745 rg
+n 60 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 66 72 6 12 re f*
+.960784 .960784 .862745 rg
+n 72 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 42 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 54 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 66 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 72 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 42 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 54 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 60 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 66 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 72 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 42 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 54 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 66 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 72 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 42 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 54 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 66 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 72 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 42 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 54 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 60 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 66 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 72 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 6 12 re f*
+.960784 .960784 .862745 rg
+n 42 0 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 0 0 12 re f*
+.960784 .960784 .862745 rg
+n 54 0 6 12 re f*
+.960784 .960784 .862745 rg
+n 60 0 0 12 re f*
+.960784 .960784 .862745 rg
+n 66 0 6 12 re f*
+BT 1 0 0 1 0 86 Tm 12 TL /F3 10 Tf .666667 .666667 .666667 rg (1 ) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (def) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (f) Tj .666667 .666667 .666667 rg (\(\):) Tj .666667 .666667 .666667 rg  T* (2 ) Tj 0 0 0 rg (     ) Tj .666667 .666667 .666667 rg (a) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (=) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (1) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (     ) Tj 0 0 0 rg (b) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (=) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (2) Tj .666667 .666667 .666667 rg  T* (4 ) Tj 0 0 0 rg (     ) Tj .666667 .666667 .666667 rg (c) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (=) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (3) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (     ) Tj 0 0 0 rg (d) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (=) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (4) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (     ) Tj 0 0 0 rg (e) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (=) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (5) Tj .666667 .666667 .666667 rg  T* (7 ) Tj 0 0 0 rg (     ) Tj .666667 .666667 .666667 rg (f) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (=) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (6) Tj .666667 .666667 .666667 rg  T* (8 ) Tj 0 0 0 rg (     ) Tj .666667 .666667 .666667 rg (g) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (=) Tj .666667 .666667 .666667 rg ( ) Tj .666667 .666667 .666667 rg (7) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+ 
+endstream
+endobj
+10 0 obj
+<<
+/Count 0 /Type /Outlines
+>>
+endobj
+11 0 obj
+<<
+/Nums [ 0 12 0 R ]
+>>
+endobj
+12 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000448 00000 n 
+0000000651 00000 n 
+0000000755 00000 n 
+0000001027 00000 n 
+0000001086 00000 n 
+0000005581 00000 n 
+0000005628 00000 n 
+0000005669 00000 n 
+trailer
+<<
+/ID 
+[<19b7a0fd1e8e4f96176fce9e6b5d3271><19b7a0fd1e8e4f96176fce9e6b5d3271>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 13
+>>
+startxref
+5703
+%%EOF


### PR DESCRIPTION
As we can't do background colours over whitespace, we dim the lines
that are not highlighted with the new class `pygments_diml`.