### PR TITLE
pdfbuilder does not return extension metdata for Sphinx

### DIFF
--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -51,6 +51,7 @@ from sphinx.locale import admonitionlabels, versionlabels
 if sphinx.__version__ >= '1.':
     from sphinx.locale import _
 
+import rst2pdf
 from rst2pdf import createpdf, pygments_code_block_directive, oddeven_directive
 from rst2pdf.log import log
 from rst2pdf.languages import get_language_available
@@ -909,3 +910,9 @@ def setup(app):
                                      project_doc_texescaped,
                                      author_texescaped,
                                      'manual'))
+
+    return {
+        'version', rst2pdf.version,
+        'parallel_read_safe': True,
+        'parallel_write_safe': False,
+    }


### PR DESCRIPTION
Since Sphinx-1.3, it expects the extensions to return its metadata on setting up.
http://www.sphinx-doc.org/en/stable/extdev/index.html#extension-metadata

At this moment, Sphinx guesses the metadata of rst2pdf.
But we're planning to drop this special treatment in nearly future (see https://github.com/sphinx-doc/sphinx/pull/4463).

This PR modifies pdfbuilder to follow the protocol for Sphinx extensions.