### PR TITLE
[WIP] Update ignore files

### DIFF
--- a/rst2pdf/tests/input/test_issue_239.ignore
+++ b/rst2pdf/tests/input/test_issue_239.ignore
@@ -1,0 +1,3 @@
+SVGIMage is backend, but cannot load warning.svg:
+
+[ERROR] image.py:187 Couldn't load image [/Users/rob/Projects/python/rst2pdf/rst2pdf/tests/input/warning.svg]

--- a/rst2pdf/tests/input/test_issue_255_2.ignore
+++ b/rst2pdf/tests/input/test_issue_255_2.ignore
@@ -1,0 +1,4 @@
+headers have keeptogether attribute set, however if the next
+item is a table, then the headers do not keep with it.
+
+Believed to be a ReportLab bug.

--- a/rst2pdf/tests/input/test_issue_390.ignore
+++ b/rst2pdf/tests/input/test_issue_390.ignore
@@ -1,0 +1,1 @@
+--config switch doesn't work.


### PR DESCRIPTION
Add messages to the `.ignore` files to explain why the test is ignored.

Also introduce the `-I` (`--ignore_ignorefiles`) switch to `autotest.py` to allow testing an ignored tes.