### PR TITLE
Fixing typo in pdfbuilder's returned dict

### DIFF
--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -912,7 +912,7 @@ def setup(app):
                                      'manual'))
 
     return {
-        'version', rst2pdf.version,
+        'version': rst2pdf.version,
         'parallel_read_safe': True,
         'parallel_write_safe': False,
     }


### PR DESCRIPTION
I ran into this error when generating a PDF through Sphinx:
```
Running Sphinx v1.5.6

Exception occurred:
  File "/usr/local/lib/python2.7/dist-packages/sphinx/application.py", line 512, in setup_extension
    mod = __import__(extension, None, None, ['setup'])
  File "/usr/local/lib/python2.7/dist-packages/rst2pdf/pdfbuilder.py", line 916
    'parallel_read_safe': True,
                        ^
SyntaxError: invalid syntax
```

It appears to be due to a typo in line 915. The change in this PR fixed the error for me.