### PR TITLE
Tiny syntax fix for a command that doesn't render in the docs

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -1261,7 +1261,7 @@ Text Annotations
 
 Text annotations are meta notes added to a page.
 
-The syntax is this:
+The syntax is this::
 
     .. raw:: pdf
 


### PR DESCRIPTION
Just noticed I couldn't see the `TextAnnotation` example properly and it's a tiny typo so here's a fix :)