### PR TITLE
#652 Set title and author correctly so that ###Title### in header/foo…

### DIFF
--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -636,8 +636,8 @@ class RstToPdf(object):
             pageTemplates=[FP],
             showBoundary=0,
             pagesize=self.styles.ps,
-            title=self.doc_title_clean,
-            author=self.doc_author,
+            title=doctree.settings.title,
+            author=doctree.settings.author,
             pageCompression=compressed)
         pdfdoc.client =self
 


### PR DESCRIPTION
…ter work again

This pull request is a quick fix for #652 https://github.com/rst2pdf/rst2pdf/issues/652