### PR TITLE
:Specify that this is *still* only a Python 2 project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python:: 2',
         'Topic :: Documentation',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Processing',


### PR DESCRIPTION
 Many people report here bugs which are python2->pytho3
 related, this should help reducing the number of people
 who get disappointed by the fact the project fails to run
 with python3.

 Even though the setup has already a check for this, adding
 this classifiers also whould point this in Pypi in case a 0.94
 release happens.

 So this should stay until the project migration is done.
