### PR TITLE
Honour the Sphinx today config setting

### DIFF
--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -583,12 +583,18 @@ class PDFWriter(writers.Writer):
             # Latex does a manual linebreak. This sucks.
             authors=self.document.settings.author.split('\\')
 
+            # Honour the "today" config setting
+            if self.config.today :
+                date = self.config.today
+            else:
+                date=ustrftime(self.config.today_fmt or _('%B %d, %Y'))
+
             # Feed data to the template, get restructured text.
             cover_text = createpdf.renderTemplate(tname=cover_file,
                                 title=self.document.settings.title or visitor.elements['title'],
                                 subtitle='%s %s'%(_('version'),self.config.version),
                                 authors=authors,
-                                date=ustrftime(self.config.today_fmt or _('%B %d, %Y'))
+                                date=date
                                 )
 
             cover_tree = docutils.core.publish_doctree(cover_text)

--- a/rst2pdf/tests/input/sphinx-issue183/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue183/conf.py
@@ -55,7 +55,7 @@ release = 'test'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue229/source/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue229/source/conf.py
@@ -55,7 +55,7 @@ release = '1'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue254/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue254/conf.py
@@ -55,7 +55,7 @@ release = '1.0.1'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue257/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue257/conf.py
@@ -55,7 +55,7 @@ release = '1.0.1'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue285/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue285/conf.py
@@ -58,7 +58,7 @@ release = '0.0'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue318/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue318/conf.py
@@ -58,7 +58,7 @@ release = '0.0'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue319/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue319/conf.py
@@ -55,7 +55,7 @@ release = '0.0.0'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue320/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue320/conf.py
@@ -55,7 +55,7 @@ release = '0.0.0'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue360/source/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue360/source/conf.py
@@ -58,7 +58,7 @@ release = '1.0'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue364/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue364/conf.py
@@ -55,7 +55,7 @@ release = 'test'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 

--- a/rst2pdf/tests/input/sphinx-issue367/source/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue367/source/conf.py
@@ -63,7 +63,7 @@ language = 'de'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+today = 'April 29, 2018'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 


### PR DESCRIPTION
Sphinx has a `today` setting that should be used instead of the current
date if it exists. Use this for the date on the cover page.

This has the useful side-effect of making it possible to use a cover page in the tests too!