### PR TITLE
Fix start-at line numbers

### DIFF
--- a/rst2pdf/pygments_code_block_directive.py
+++ b/rst2pdf/pygments_code_block_directive.py
@@ -179,7 +179,7 @@ def code_block_directive(name, arguments, options, content, lineno,
                 # patch mmueller end
 
                 content = content[after_index:]
-                line_offset = len(content[:after_index].splitlines())
+                line_offset = len(content[:after_index].splitlines()) - 1
 
             after_text = options.get('start-after', None)
             if after_text:

--- a/rst2pdf/tests/input/test_issue_310.txt
+++ b/rst2pdf/tests/input/test_issue_310.txt
@@ -1,10 +1,17 @@
+We are testing include a file using ``:include:`` with line numbers enabled using ``:linenos:``.
+
+
 In the following code blocks, the line numbers always should match the numbers
 in the content.
+
+First test: ``:linenos_offset:``
 
 .. code-block:: text
    :linenos:
    :linenos_offset:
    :include: include
+
+Second test: ``:linenos_offset:`` & ``:start-at: Line 3``
 
 .. code-block:: text
    :linenos:
@@ -12,11 +19,15 @@ in the content.
    :linenos_offset:
    :start-at: Line 3
 
+Third test: ``:linenos_offset:`` & ``start-after: Line 2``
+
 .. code-block:: text
    :linenos:
    :include: include
    :linenos_offset:
    :start-after: Line 2
+
+Fourth test: ``:linenos_offset:`` & ``start-after: Lin``
 
 .. code-block:: text
    :linenos:
@@ -26,10 +37,14 @@ in the content.
 
 In the following, the line numbers always start at 1:
 
+Fifth test: ``start-at: Line 3``
+
 .. code-block:: text
    :linenos:
    :include: include
    :start-at: Line 3
+
+Sixth test: ``start-after: Line 2``
 
 .. code-block:: text
    :linenos:

--- a/rst2pdf/tests/md5/test_issue_310.json
+++ b/rst2pdf/tests/md5/test_issue_310.json
@@ -7,6 +7,7 @@ bad_md5 = [
 
 good_md5 = [
         '500d4acf6d33ac6958b916b47964bb0c',
+        '939b8f9fa1a592df9221c15657088bff',
         'ce103e35ace464fbc9ad923e02633433',
         'd2a9e42f125f8a2f411541f110de0b19',
         'sentinel'

--- a/rst2pdf/tests/reference/test_issue_310.pdf
+++ b/rst2pdf/tests/reference/test_issue_310.pdf
@@ -1,0 +1,386 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Outlines 9 0 R /PageLabels 10 0 R /PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title () /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Length 6992
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 753.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (We are testing include a file using ) Tj /F2 10 Tf 0 0 0 rg (:include:) Tj /F1 10 Tf 0 0 0 rg ( with line numbers enabled using ) Tj /F2 10 Tf 0 0 0 rg (:linenos:) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 735.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (In the following code blocks, the line numbers always should match the numbers in the content.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 717.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (First test: ) Tj /F2 10 Tf 0 0 0 rg (:linenos_offset:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 623.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 84 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 6 12 re f*
+BT 1 0 0 1 0 62 Tm 12 TL /F2 10 Tf 0 0 0 rg (1 ) Tj 0 0 0 rg (Line 1) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (Line 2) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (Line 3) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (Line 4) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (Line 5) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (Line 6) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 603.8236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Second test: ) Tj /F2 10 Tf 0 0 0 rg (:linenos_offset:) Tj /F1 10 Tf 0 0 0 rg ( & ) Tj /F2 10 Tf 0 0 0 rg (:start-at:) Tj ( ) Tj (Line) Tj ( ) Tj (3) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 522.6236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 72 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+BT 1 0 0 1 0 50 Tm 12 TL /F2 10 Tf 0 0 0 rg (3 ) Tj 0 0 0 rg (Line 3) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (Line 4) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (Line 5) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (Line 6) Tj 0 0 0 rg  T* (7 ) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 502.6236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Third test: ) Tj /F2 10 Tf 0 0 0 rg (:linenos_offset:) Tj /F1 10 Tf 0 0 0 rg ( & ) Tj /F2 10 Tf 0 0 0 rg (start-after:) Tj ( ) Tj (Line) Tj ( ) Tj (2) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 421.4236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 72 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+BT 1 0 0 1 0 50 Tm 12 TL /F2 10 Tf 0 0 0 rg (3 ) Tj 0 0 0 rg (Line 3) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (Line 4) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (Line 5) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (Line 6) Tj 0 0 0 rg  T* (7 ) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 401.4236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fourth test: ) Tj /F2 10 Tf 0 0 0 rg (:linenos_offset:) Tj /F1 10 Tf 0 0 0 rg ( & ) Tj /F2 10 Tf 0 0 0 rg (start-after:) Tj ( ) Tj (Lin) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 308.2236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 84 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 30 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 6 12 re f*
+BT 1 0 0 1 0 62 Tm 12 TL /F2 10 Tf 0 0 0 rg (2 ) Tj 0 0 0 rg (e 1) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (Line 2) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (Line 3) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (Line 4) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (Line 5) Tj 0 0 0 rg  T* (7 ) Tj 0 0 0 rg (Line 6) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 288.2236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (In the following, the line numbers always start at 1:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 270.2236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fifth test: ) Tj /F2 10 Tf 0 0 0 rg (start-at:) Tj ( ) Tj (Line) Tj ( ) Tj (3) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 189.0236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 72 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+BT 1 0 0 1 0 50 Tm 12 TL /F2 10 Tf 0 0 0 rg (1 ) Tj 0 0 0 rg (Line 3) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (Line 4) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (Line 5) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (Line 6) Tj 0 0 0 rg  T* (5 ) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 169.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Sixth test: ) Tj /F2 10 Tf 0 0 0 rg (start-after:) Tj ( ) Tj (Line) Tj ( ) Tj (2) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 87.82362 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 72 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 48 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+BT 1 0 0 1 0 50 Tm 12 TL /F2 10 Tf 0 0 0 rg (1 ) Tj 0 0 0 rg (Line 3) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (Line 4) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (Line 5) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (Line 6) Tj 0 0 0 rg  T* (5 ) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+ 
+endstream
+endobj
+9 0 obj
+<<
+/Count 0 /Type /Outlines
+>>
+endobj
+10 0 obj
+<<
+/Nums [ 0 11 0 R ]
+>>
+endobj
+11 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000326 00000 n 
+0000000529 00000 n 
+0000000632 00000 n 
+0000000889 00000 n 
+0000000948 00000 n 
+0000007991 00000 n 
+0000008037 00000 n 
+0000008078 00000 n 
+trailer
+<<
+/ID 
+[<2db82f8d13fc9aad0f6ac8c1445975f3><2db82f8d13fc9aad0f6ac8c1445975f3>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 12
+>>
+startxref
+8112
+%%EOF


### PR DESCRIPTION
In test_issue_310, the line numbers for the :start-at: test when using :linenos_offset: are off by one.

Addresses one of the problems with #662. 