### PR TITLE
Fix start-after line numbers

### DIFF
--- a/rst2pdf/pygments_code_block_directive.py
+++ b/rst2pdf/pygments_code_block_directive.py
@@ -188,8 +188,16 @@ def code_block_directive(name, arguments, options, content, lineno,
                 if after_index < 0:
                     raise state_machine.reporter.severe('Problem with "start-after" option of "%s" '
                                       'code-block directive:\nText not found.' % options['start-after'])
-                line_offset = len(content[:after_index + len(after_text)].splitlines())
-                content = content[after_index + len(after_text):]
+                after_index = after_index + len(after_text)
+
+                # Move the after_index to the start of the line after the match
+                for char in content[after_index:]:
+                    if char == u'\n':
+                        break
+                    after_index += 1
+
+                line_offset = len(content[:after_index].splitlines())
+                content = content[after_index:]
 
 
             # same changes here for the same reason

--- a/rst2pdf/tests/input/test_issue_310.ignore
+++ b/rst2pdf/tests/input/test_issue_310.ignore
@@ -1,1 +1,0 @@
-Line numbers are incorrect

--- a/rst2pdf/tests/md5/test_issue_310.json
+++ b/rst2pdf/tests/md5/test_issue_310.json
@@ -7,7 +7,7 @@ bad_md5 = [
 
 good_md5 = [
         '500d4acf6d33ac6958b916b47964bb0c',
-        '939b8f9fa1a592df9221c15657088bff',
+        '9fa3280dc3c2e47412d20ea00a4a002c',
         'ce103e35ace464fbc9ad923e02633433',
         'd2a9e42f125f8a2f411541f110de0b19',
         'sentinel'

--- a/rst2pdf/tests/reference/test_issue_310.pdf
+++ b/rst2pdf/tests/reference/test_issue_310.pdf
@@ -43,7 +43,7 @@ endobj
 endobj
 8 0 obj
 <<
-/Length 6992
+/Length 6975
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -219,7 +219,7 @@ q
 .960784 .960784 .862745 rg
 n 0 60 6 12 re f*
 .960784 .960784 .862745 rg
-n 30 60 0 12 re f*
+n 48 60 0 12 re f*
 .960784 .960784 .862745 rg
 n 0 48 6 12 re f*
 .960784 .960784 .862745 rg
@@ -237,8 +237,8 @@ n 0 12 6 12 re f*
 .960784 .960784 .862745 rg
 n 48 12 0 12 re f*
 .960784 .960784 .862745 rg
-n 0 0 6 12 re f*
-BT 1 0 0 1 0 62 Tm 12 TL /F2 10 Tf 0 0 0 rg (2 ) Tj 0 0 0 rg (e 1) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (Line 2) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (Line 3) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (Line 4) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (Line 5) Tj 0 0 0 rg  T* (7 ) Tj 0 0 0 rg (Line 6) Tj T* ET
+n 0 0 12 12 re f*
+BT 1 0 0 1 0 62 Tm 12 TL /F2 10 Tf 0 0 0 rg (2 ) Tj 0 0 0 rg (Line 2) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (Line 3) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (Line 4) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (Line 5) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (Line 6) Tj 0 0 0 rg  T* (7 ) Tj T* ET
 Q
 Q
 Q
@@ -368,9 +368,9 @@ xref
 0000000632 00000 n 
 0000000889 00000 n 
 0000000948 00000 n 
-0000007991 00000 n 
-0000008037 00000 n 
-0000008078 00000 n 
+0000007974 00000 n 
+0000008020 00000 n 
+0000008061 00000 n 
 trailer
 <<
 /ID 
@@ -382,5 +382,5 @@ trailer
 /Size 12
 >>
 startxref
-8112
+8095
 %%EOF


### PR DESCRIPTION
In test_issue_310, the line numbers for the :start-after: test when using :linenos_offset: are off by one if you the start-after text is in the middle of a line as you can see here:

![screen shot 2018-05-04 at 18 22 48](https://user-images.githubusercontent.com/33135/39642036-2d373898-4fc8-11e8-826a-caf43eb42f00.png)

I have fixed this by applying the same approach to start-after that #410 does to start-at.

Issue #410, which moved the start point to the start of the line when using `start-at`, and I think that we should move the start point to the start of the next line when using `start-after` as starting half-way through a line is weird!

The result now looks like:

![screen shot 2018-05-04 at 18 25 49](https://user-images.githubusercontent.com/33135/39642149-9a8e26d6-4fc8-11e8-862a-b184d2429aa6.png)

Anyone disagree?



This is the second fix for #662.