### PR TITLE
Test header/footer token replacement in template definitions

### DIFF
--- a/rst2pdf/tests/input/test_header_footer_in_stylesheet.style
+++ b/rst2pdf/tests/input/test_header_footer_in_stylesheet.style
@@ -1,0 +1,17 @@
+pageSetup:
+    firstTemplate: myLayout
+    margin-bottom: 8mm
+    margin-left: 12mm
+    margin-right: 12mm
+    margin-top: 8mm
+
+pageTemplates:
+    myLayout:
+        frames:  [[0cm, 0cm, 100%, 100%]]
+        defaultHeader =
+            Header: Section: ###Section###, Title: ###Title###, Page ###Page### of ###Total###
+        defaultFooter =
+            Footer: Section: ###Section###, Title: ###Title###, Page ###Page### of ###Total###
+        showFooter: true
+        showHeader: true
+

--- a/rst2pdf/tests/input/test_header_footer_in_stylesheet.txt
+++ b/rst2pdf/tests/input/test_header_footer_in_stylesheet.txt
@@ -1,0 +1,20 @@
+Test Doc
+========
+
+
+The Section
+-----------
+
+The content
+
+
+.. raw:: pdf
+
+    PageBreak
+
+
+
+Another Section
+---------------
+
+Some more content

--- a/rst2pdf/tests/md5/test_header_footer_in_stylesheet.json
+++ b/rst2pdf/tests/md5/test_header_footer_in_stylesheet.json
@@ -1,0 +1,13 @@
+bad_md5 = [
+        'sentinel'
+]
+
+good_md5 = [
+        '8d08a7a56889d1a35ac2add3ac54b40e',
+        'sentinel'
+]
+
+unknown_md5 = [
+        'sentinel'
+]
+

--- a/rst2pdf/tests/reference/test_header_footer_in_stylesheet.pdf
+++ b/rst2pdf/tests/reference/test_header_footer_in_stylesheet.pdf
@@ -1,0 +1,232 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 11 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 13 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 11 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Outlines 8 0 R /PageLabels 14 0 R /PageMode /UseNone /Pages 11 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (Test Doc) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 2 /First 9 0 R /Last 10 0 R /Type /Outlines
+>>
+endobj
+9 0 obj
+<<
+/Dest [ 4 0 R /XYZ 40.01575 751.0394 0 ] /Next 10 0 R /Parent 8 0 R /Title (The Section)
+>>
+endobj
+10 0 obj
+<<
+/Dest [ 5 0 R /XYZ 40.01575 787.0394 0 ] /Parent 8 0 R /Prev 9 0 R /Title (Another Section)
+>>
+endobj
+11 0 obj
+<<
+/Count 2 /Kids [ 4 0 R 5 0 R ] /Type /Pages
+>>
+endobj
+12 0 obj
+<<
+/Length 872
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 763.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 4 Tm /F2 20 Tf 24 TL 215.392 0 Td (Test Doc) Tj T* -215.392 0 Td ET
+Q
+Q
+q
+1 0 0 1 40.01575 730.0394 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (The Section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 712.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The content) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 712.0394 cm
+Q
+q
+1 0 0 1 34.01575 807.2126 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 0 2 Tm  T* ET
+q
+1 0 0 1 20 0 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Header: Section: The Section, Title: Test Doc, Page 1 of 2) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 34.01575 22.67717 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 0 2 Tm  T* ET
+q
+1 0 0 1 20 0 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Footer: Section: The Section, Title: Test Doc, Page 1 of 2) Tj T* ET
+Q
+Q
+q
+Q
+Q
+ 
+endstream
+endobj
+13 0 obj
+<<
+/Length 763
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 766.0394 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (Another Section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 748.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Some more content) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 748.0394 cm
+Q
+q
+1 0 0 1 34.01575 807.2126 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 0 2 Tm  T* ET
+q
+1 0 0 1 20 0 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Header: Section: Another Section, Title: Test Doc, Page 2 of 2) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 34.01575 22.67717 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 0 2 Tm  T* ET
+q
+1 0 0 1 20 0 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Footer: Section: Another Section, Title: Test Doc, Page 2 of 2) Tj T* ET
+Q
+Q
+q
+Q
+Q
+ 
+endstream
+endobj
+14 0 obj
+<<
+/Nums [ 0 15 0 R 1 16 0 R ]
+>>
+endobj
+15 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+16 0 obj
+<<
+/S /D /St 2
+>>
+endobj
+xref
+0 17
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000538 00000 n 
+0000000743 00000 n 
+0000000847 00000 n 
+0000001112 00000 n 
+0000001184 00000 n 
+0000001294 00000 n 
+0000001408 00000 n 
+0000001474 00000 n 
+0000002397 00000 n 
+0000003211 00000 n 
+0000003261 00000 n 
+0000003295 00000 n 
+trailer
+<<
+/ID 
+[<39967b6aae7a6d9c8775056c3c67ad34><39967b6aae7a6d9c8775056c3c67ad34>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 17
+>>
+startxref
+3329
+%%EOF


### PR DESCRIPTION
Ensure that token replacement works when you use them within the `defaultHeader` & `defaultFooter` directives in a stylesheet.

Related to #652, but not directly the same thing.