### PR TITLE
Release input file handle

### DIFF
--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -1389,6 +1389,7 @@ def main(_args=None):
             sys.exit(1)
         options.output = args.pop()
 
+    close_infile = False
     if args[0] == '-':
         infile = sys.stdin
         options.basedir=os.getcwd()
@@ -1400,6 +1401,7 @@ def main(_args=None):
         options.basedir=os.path.dirname(os.path.abspath(filename))
         try:
             infile = open(filename)
+            close_infile = True
         except IOError as e:
             log.error(e)
             sys.exit(1)
@@ -1493,8 +1495,10 @@ def main(_args=None):
                     source_path=options.infile.name,
                     output=options.outfile,
                     compressed=options.compressed)
-    options.infile.close()
-                    
+
+    if close_infile:
+        options.infile.close()
+
 # Ugly hack that fixes Issue 335
 reportlab.lib.utils.ImageReader.__deepcopy__ = lambda self,*x: copy(self)
 

--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -1493,7 +1493,8 @@ def main(_args=None):
                     source_path=options.infile.name,
                     output=options.outfile,
                     compressed=options.compressed)
-
+    options.infile.close()
+                    
 # Ugly hack that fixes Issue 335
 reportlab.lib.utils.ImageReader.__deepcopy__ = lambda self,*x: copy(self)
 


### PR DESCRIPTION
Release the input file handle if we opened it. 

Rationale from #592:

> I'm using rst2pdf from python code (a fabric task) and using a temporary file as an input file to add substitution variables. The problem I have is that rst2pdf.createpdf.main does not release the handler to this input file, and therefore my code cannot delete the temporary file after the pdf has been created. As there is no way to retrieve that file handler the only way to solve that is to release it from within createpdf.main.

Builds on #592 by rebasing and only closing the handler if we opened it.