### PR TITLE
Fix #678

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@
 * Fixed: ``:linenos_offset:`` now works again
 * Fixed: Removed debugging print statement when using line blocks
 * Fixed: Removed uniconverter from setup (issue 487)
+* Fixed: Error when using --date-invariant with newer reportlab versions (Issue 678)
 
 
 0.93 (2012-12-18)

--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -1521,7 +1521,7 @@ def patch_PDFDate():
     class PDFDate(pdfdoc.PDFObject):
         __PDFObject__ = True
         # gmt offset now suppported
-        def __init__(self, invariant=True, dateFormatter=None):
+        def __init__(self, invariant=True, ts=None, dateFormatter=None):
             now = (2000,01,01,00,00,00,0)
             self.date = now[:6]
             self.dateFormatter = dateFormatter


### PR DESCRIPTION
Fix problem when using --date-invariant with newer reportlab versions.