### PR TITLE
Suggest working fork of Wordaxe in manual

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -1423,8 +1423,8 @@ If you want good looking documents, you want to enable hyphenation.
 
 To do it, you need to install Wordaxe [#]_.
 
-.. [#] You can get Wordaxe from http://deco-cow.sf.net. Version 1.0.0 or later is
-       recommended.
+.. [#] Use Roberto Alsina's fork of Wordaxe from https://github.com/ralsina/wordaxe as
+       this works with later versions of ReportLab.
 
 If after installing it you get the letter "s" or a black square instead of a hyphen,
 that means you need to replace the rl_codecs.py file from reportlab with the one from


### PR DESCRIPTION
As the original version of Wordaxe doesn't work with later versions of
ReportLab and hasn't been updated since 2010, point users to Roberto
Alsina's fork.