### PR TITLE
[bugfix] Close infile, not options.infile

### DIFF
--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -1497,7 +1497,7 @@ def main(_args=None):
                     compressed=options.compressed)
 
     if close_infile:
-        options.infile.close()
+        infile.close()
 
 # Ugly hack that fixes Issue 335
 reportlab.lib.utils.ImageReader.__deepcopy__ = lambda self,*x: copy(self)


### PR DESCRIPTION
`infile` is always the file handle, `options.infile` becomes the rst text if preprocessing is enabled, so we can't use it to close the file handle.

This fixes this error:

```
Traceback (most recent call last):
  File "/Users/rob/.pyenv/versions/tools2/bin/rst2pdf", line 11, in <module>
    load_entry_point('rst2pdf', 'console_scripts', 'rst2pdf')()
  File "/Users/rob/Projects/python/rst2pdf/rst2pdf/createpdf.py", line 1500, in main
    options.infile.close()
AttributeError: 'DummyFile' object has no attribute 'close'
```