### PR TITLE
Ignore .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ rst2pdf/tests/output/*.pdf
 rst2pdf/tests/output/*.log
 rst2pdf/tests/input/*/_build
 .vscode/
+.python-version


### PR DESCRIPTION
If you're using pyenv, you can set the python version/virtualenv that
you want to use while developing in .python-version, so this is a good
file to ignore.