### PR TITLE
Update requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ addons:
   apt:
     packages:
     - inkscape
+    - texlive-latex-base
+    - dvipng
 
 language: python
 python:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@
 {next}
 ------
 
+* Sphinx config setting pdf_invariant works properly now (Issue #718)
+* Updated reportlab dependency to 3.5.12 and Sphinx to 1.7.9 (Issue #718)
 * Updated reportlab dependency to 3.5.10 (Issue #714)
 * Fixed handling of empty documents, they now generate a single empty page (Issue 547)
 * Fix handling of non-http/ftp URLs (Issue #549)
@@ -16,7 +18,7 @@
 * Changed: We now use PILLOW rather than PIL
 * Fixed: Using ``:start-after:`` with ``linenos_offset`` now displays the correct line number
 * Fixed: Using ``:start-at:`` with ``linenos_offset`` now displays the correct line number
-* Fixed: Inline ``:math:` works again as we now use quoted attributes for HTML ``<img>`` tags (issue 567)
+* Fixed: Inline ``:math:`` works again as we now use quoted attributes for HTML ``<img>`` tags (issue 567)
 * Fixed: sphinx+rst2pdf now works with automodule directive Sphinx >= 1.4 (issue 566)
 * Fixed: CreationDate metadata shows correct date using Sphinx (issue 525)
 * Fixed: ``:alt:`` option now works for plantuml extension

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ reportlab==3.5.12
 requests==2.21.0          # via sphinx
 six==1.12.0               # via cycler, html5lib, matplotlib, packaging, python-dateutil, sphinx, xhtml2pdf
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.8.2
+sphinx==1.7.9
 sphinxcontrib-websupport==1.1.0  # via sphinx
 subprocess32==3.5.3       # via matplotlib
 svg2rlg==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,41 +5,38 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 aafigure==0.6
-alabaster==0.7.10         # via sphinx
-babel==2.5.1              # via sphinx
-backports.functools-lru-cache==1.4  # via matplotlib
-certifi==2017.11.5        # via requests
+alabaster==0.7.12         # via sphinx
+babel==2.6.0              # via sphinx
+backports.functools-lru-cache==1.5  # via matplotlib
+certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
 cycler==0.10.0            # via matplotlib
 docutils==0.14
-html5lib==0.999999999     # via xhtml2pdf
-idna==2.6                 # via requests
-imagesize==0.7.1          # via sphinx
+html5lib==1.0.1           # via xhtml2pdf
+idna==2.8                 # via requests
+imagesize==1.1.0          # via sphinx
 jinja2==2.10              # via sphinx
-markupsafe==1.0           # via jinja2
-matplotlib==2.1.0
-numpy==1.13.3             # via matplotlib
-olefile==0.44             # via pillow
+kiwisolver==1.0.1         # via matplotlib
+markupsafe==1.1.0         # via jinja2
+matplotlib==2.2.3
+numpy==1.15.4             # via matplotlib
+packaging==18.0           # via sphinx
 pdfrw==0.4
-pillow==4.3.0
-pygments==2.2.0
-pyparsing==2.2.0          # via matplotlib
-pypdf2==1.26.0            # via xhtml2pdf
-python-dateutil==2.6.1    # via matplotlib
-pytz==2017.3              # via babel, matplotlib
-reportlab==3.5.10
-requests==2.20         # via sphinx
-six==1.11.0               # via cycler, html5lib, matplotlib, python-dateutil, sphinx
+pillow==5.3.0
+pygments==2.3.0
+pyparsing==2.3.0          # via matplotlib, packaging
+pypdf2==1.26.0
+python-dateutil==2.7.5    # via matplotlib
+pytz==2018.7              # via babel, matplotlib
+reportlab==3.5.12
+requests==2.21.0          # via sphinx
+six==1.12.0               # via cycler, html5lib, matplotlib, packaging, python-dateutil, sphinx, xhtml2pdf
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.6.5
-sphinxcontrib-websupport==1.0.1  # via sphinx
-subprocess32==3.2.7       # via matplotlib
+sphinx==1.8.2
+sphinxcontrib-websupport==1.1.0  # via sphinx
+subprocess32==3.5.3       # via matplotlib
 svg2rlg==0.3
-typing==3.6.2             # via sphinx
-urllib3==1.22             # via requests
+typing==3.6.6             # via sphinx
+urllib3==1.24.1           # via requests
 webencodings==0.5.1       # via html5lib
-xhtml2pdf==0.0.6
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip                       # via reportlab
-# setuptools                # via html5lib, reportlab, sphinx
+xhtml2pdf==0.2.3

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -64,6 +64,7 @@ class PDFBuilder(Builder):
     def init(self):
         self.docnames = []
         self.document_data = []
+        self.spinx_logger = sphinx.util.logging.getLogger(__name__)
 
     def write(self, *ignored):
 
@@ -82,7 +83,7 @@ class PDFBuilder(Builder):
                     opts=entry[4]
                 else:
                     opts={}
-                self.info("processing " + targetname + "... ", nonl=1)
+                self.spinx_logger.info("processing " + targetname + "... ")
                 self.opts = opts
                 class dummy:
                     extensions=self.config.pdf_extensions
@@ -124,14 +125,14 @@ class PDFBuilder(Builder):
                     appendices=opts.get('pdf_appendices', self.config.pdf_appendices) or [])
                 doctree.settings.author=author
                 doctree.settings.title=title
-                self.info("done")
-                self.info("writing " + targetname + "... ", nonl=1)
+                self.spinx_logger.info("done")
+                self.spinx_logger.info("writing " + targetname + "... ")
                 docwriter.write(doctree, destination)
-                self.info("done")
+                self.spinx_logger.info("done")
             except Exception as e:
                 log.error(str(e))
                 print_exc()
-                self.info(red("FAILED"))
+                self.spinx_logger.info(red("FAILED"))
 
     def init_document_data(self):
         preliminary_document_data = map(list, self.config.pdf_documents)
@@ -158,7 +159,7 @@ class PDFBuilder(Builder):
         # check how the LaTeX builder does it.
 
         self.docnames = set([docname])
-        self.info(darkgreen(docname) + " ", nonl=1)
+        self.spinx_logger.info(darkgreen(docname) + " ")
         def process_tree(docname, tree):
             tree = tree.deepcopy()
             for toctreenode in tree.traverse(addnodes.toctree):
@@ -166,7 +167,7 @@ class PDFBuilder(Builder):
                 includefiles = map(str, toctreenode['includefiles'])
                 for includefile in includefiles:
                     try:
-                        self.info(darkgreen(includefile) + " ", nonl=1)
+                        self.spinx_logger.info(darkgreen(includefile) + " ")
                         subtree = process_tree(includefile,
                         self.env.get_doctree(includefile))
                         self.docnames.add(includefile)
@@ -250,7 +251,7 @@ class PDFBuilder(Builder):
             )
             # In HTML this is handled with a Jinja template, domainindex.html
             # We have to generate docutils stuff right here in the same way.
-            self.info(' ' + indexname, nonl=1)
+            self.spinx_logger.info(' ' + indexname)
             print
 
             output=['DUMMY','=====','',
@@ -283,17 +284,16 @@ class PDFBuilder(Builder):
 
         if appendices:
             tree.append(nodes.raw(text='OddPageBreak %s'%self.page_template, format='pdf'))
-            self.info()
-            self.info('adding appendixes...', nonl=1)
+            self.spinx_logger.info()
+            self.spinx_logger.info('adding appendixes...')
             for docname in appendices:
-                self.info(darkgreen(docname) + " ", nonl=1)
+                self.spinx_logger.info(darkgreen(docname) + " ")
                 appendix = self.env.get_doctree(docname)
                 appendix['docname'] = docname
                 tree.append(appendix)
-            self.info('done')
+            self.spinx_logger.info('done')
 
-        self.info()
-        self.info("resolving references...")
+        self.spinx_logger.info("resolving references...")
         #print tree
         #print '--------------'
         self.env.resolve_references(tree, docname, self)

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -908,7 +908,7 @@ def setup(app):
     app.add_config_value('pdf_default_dpi', 300, None)
     app.add_config_value('pdf_extensions',['vectorpdf'], None)
     app.add_config_value('pdf_page_template','cutePage', None)
-    app.add_config_value('pdf_invariant','False', None)
+    app.add_config_value('pdf_invariant',False, None)
     app.add_config_value('pdf_real_footnotes','False', None)
     app.add_config_value('pdf_use_toc','True', None)
     app.add_config_value('pdf_toc_depth',9999, None)

--- a/rst2pdf/tests/input/sphinx-issue168/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue168/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
+extensions = ['sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/rst2pdf/tests/input/sphinx-issue168/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue168/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
+extensions = ['rst2pdf.pdfbuilder']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/rst2pdf/tests/input/sphinx-issue229/source/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue229/source/conf.py
@@ -266,3 +266,5 @@ pdf_use_coverpage = True
 
 # Set the default DPI for images
 #pdf_default_dpi = 72
+
+pdf_invariant = True

--- a/rst2pdf/tests/input/sphinx-issue251/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue251/conf.py
@@ -23,8 +23,6 @@ import sys, os
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 
-# It's probably a good idea to use pdfmath BEFORE pngmath
-
 extensions = ['rst2pdf.pdfbuilder','sphinx.ext.graphviz']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/rst2pdf/tests/input/sphinx-issue254/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue254/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
+extensions = ['sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/rst2pdf/tests/input/sphinx-issue257/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue257/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
+extensions = ['sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/rst2pdf/tests/input/sphinx-issue280/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue280/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
+extensions = ['sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/rst2pdf/tests/input/sphinx-issue284/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue284/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
+extensions = ['sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.graphviz', 'rst2pdf.pdfbuilder']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/rst2pdf/tests/input/sphinx-issue285/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue285/conf.py
@@ -220,3 +220,5 @@ man_pages = [
     ('index', 'issue285', u'Issue 285 Documentation',
      [u'Roberto Alsina'], 1)
 ]
+
+pdf_invariant = True

--- a/rst2pdf/tests/input/sphinx-issue318/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue318/conf.py
@@ -224,3 +224,4 @@ man_pages = [
      [u'Roberto Alsina'], 1)
 ]
 
+pdf_invariant = True

--- a/rst2pdf/tests/input/sphinx-issue318/test.rst
+++ b/rst2pdf/tests/input/sphinx-issue318/test.rst
@@ -16,7 +16,7 @@ Contents:
 
    Describes a method with parameters and types.
 
-.. cpp:function:: bool namespaced::theclass::method(arg1, arg2)
+.. cpp:function:: bool namespaced::theclass::method2(arg1, arg2)
 
    Describes a method without types.
 

--- a/rst2pdf/tests/input/sphinx-issue319/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue319/conf.py
@@ -192,3 +192,5 @@ latex_documents = [
 
 # If false, no module index is generated.
 #latex_use_modindex = True
+
+pdf_invariant = True

--- a/rst2pdf/tests/input/sphinx-issue360/source/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue360/source/conf.py
@@ -221,3 +221,5 @@ pdf_documents = [
 pdf_stylesheets = ['sphinx','a4','ja']
 
 pdf_font_path = ['../..']
+
+pdf_invariant = True

--- a/rst2pdf/tests/input/sphinx-issue367/source/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue367/source/conf.py
@@ -291,3 +291,4 @@ pdf_default_dpi = 300
 
 pdf_page_template = 'customPage'
 
+pdf_invariant = True

--- a/rst2pdf/tests/md5/sphinx-issue318.json
+++ b/rst2pdf/tests/md5/sphinx-issue318.json
@@ -3,8 +3,8 @@ bad_md5 = [
 ]
 
 good_md5 = [
-        '543d0a3bd7a4ab53f4162da8bfd020d4',
-        'c1429c8746b7166c908cd36f7d30bc4c',
+        '89abcc47633571fc204dbd6edb7e71ee',
+        'b4773be529bb834e1ecd2756b28bc2e7',
         'sentinel'
 ]
 

--- a/rst2pdf/tests/md5/test_issue_311.json
+++ b/rst2pdf/tests/md5/test_issue_311.json
@@ -4,8 +4,7 @@ bad_md5 = [
 ]
 
 good_md5 = [
-        'bd4e13dcb19f881502db86e19ee3a3a5',
-	'15c8619a9e8b47a424c20d5a9c62405b',
+        '15c8619a9e8b47a424c20d5a9c62405b',
         '25df926ca3c272c9dd6c0f44d3732d75',
         '3584f078f7dc8cee8891ae076d654ffe',
         '4b9ed29aa5f75cc7fab775eb813b1dea',
@@ -14,9 +13,11 @@ good_md5 = [
         '748f66b9b27c2ce8803c3886eeca46fe',
         '9b9d666fc1e9a7764553da13f9563aca',
         'a6974102090d14035212c342eab04de2',
+        'abe910423a3a6af5082e97828eeaf185',
         'b1039a1ea8a62bc3ab3ad431a7dbaa76',
         'b2212727fdc7fe23a80ab354bc4637e2',
         'b8f4b77f0198336834ecf6bf40718960',
+        'bd4e13dcb19f881502db86e19ee3a3a5',
         'e2928937549c929c751e7d744cbca016',
         'e36637fc041e0ee7a0f6a243d334490e',
         'sentinel'

--- a/rst2pdf/tests/md5/test_issue_311.json
+++ b/rst2pdf/tests/md5/test_issue_311.json
@@ -10,6 +10,7 @@ good_md5 = [
         '4b9ed29aa5f75cc7fab775eb813b1dea',
         '4c305a8981095dd4b0b6f913232e6c2f',
         '50a5ae0f9ed172cc9773e809749fb2bc',
+        '5baa91c9a16fc5de6e034fc7f7fa7107',
         '748f66b9b27c2ce8803c3886eeca46fe',
         '9b9d666fc1e9a7764553da13f9563aca',
         'a6974102090d14035212c342eab04de2',

--- a/rst2pdf/tests/md5/test_raw_html.json
+++ b/rst2pdf/tests/md5/test_raw_html.json
@@ -7,6 +7,7 @@ good_md5 = [
         '773266b4c02ead93f2d1251a44e20a90',
         'bf103e38f2933f65c7fa79811a755c8e',
         'c9a3a2eeda57633ab434393bd4f1f3e4',
+        'daf8151a895a2a1e4864ffe56e7223d4',
         'sentinel'
 ]
 

--- a/rst2pdf/tests/reference/sphinx-issue318.pdf
+++ b/rst2pdf/tests/reference/sphinx-issue318.pdf
@@ -158,37 +158,37 @@ endobj
 endobj
 26 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 699.0394 0 ] /Rect [ 40.01575 581.4394 244.5557 593.4394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 729.0394 0 ] /Rect [ 40.01575 581.4394 244.5557 593.4394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 27 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 729.0394 0 ] /Rect [ 247.3357 581.4394 258.4557 593.4394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 699.0394 0 ] /Rect [ 40.01575 563.4394 250.1157 575.4394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 28 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 639.0394 0 ] /Rect [ 40.01575 533.0394 165.0757 545.0394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 639.0394 0 ] /Rect [ 40.01575 515.0394 165.0757 527.0394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 29 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 435.0394 0 ] /Rect [ 40.01575 484.6394 108.3657 496.6394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 435.0394 0 ] /Rect [ 40.01575 466.6394 108.3657 478.6394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 30 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 435.0394 0 ] /Rect [ 40.01575 436.2394 152.8157 448.2394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 435.0394 0 ] /Rect [ 40.01575 418.2394 152.8157 430.2394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 31 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 573.0394 0 ] /Rect [ 40.01575 387.8394 192.8557 399.8394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 573.0394 0 ] /Rect [ 40.01575 369.8394 192.8557 381.8394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 32 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 573.0394 0 ] /Rect [ 40.01575 369.8394 175.0557 381.8394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 573.0394 0 ] /Rect [ 40.01575 351.8394 175.0557 363.8394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 33 0 obj
@@ -342,7 +342,7 @@ endstream
 endobj
 47 0 obj
 <<
-/Length 1308
+/Length 1248
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -372,7 +372,6 @@ q
 1 0 0 1 443.2441 57 cm
 q
 0 0 .501961 rg
-0 0 .501961 RG
 BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (1) Tj T* -66.44 0 Td ET
 Q
 Q
@@ -386,7 +385,6 @@ q
 1 0 0 1 443.2441 39 cm
 q
 0 0 .501961 rg
-0 0 .501961 RG
 BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (1) Tj T* -66.44 0 Td ET
 Q
 Q
@@ -400,7 +398,6 @@ q
 1 0 0 1 443.2441 21 cm
 q
 0 0 .501961 rg
-0 0 .501961 RG
 BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (3) Tj T* -66.44 0 Td ET
 Q
 Q
@@ -414,7 +411,6 @@ q
 1 0 0 1 443.2441 3 cm
 q
 0 0 .501961 rg
-0 0 .501961 RG
 BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (5) Tj T* -66.44 0 Td ET
 Q
 Q
@@ -444,7 +440,7 @@ endstream
 endobj
 49 0 obj
 <<
-/Length 7151
+/Length 7152
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -488,7 +484,7 @@ Q
 q
 1 0 0 1 40.01575 697.0394 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (bool ) Tj /F3 10 Tf 0 0 0 rg (namespaced::theclass::) Tj /F4 10 Tf 0 0 0 rg (method) Tj /F1 10 Tf 0 0 0 rg ( \() Tj /F3 10 Tf 0 0 0 rg (arg1) Tj /F1 10 Tf 0 0 0 rg (, ) Tj /F3 10 Tf 0 0 0 rg (arg2) Tj /F1 10 Tf 0 0 0 rg (\)) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (bool ) Tj /F3 10 Tf 0 0 0 rg (namespaced::theclass::) Tj /F4 10 Tf 0 0 0 rg (method2) Tj /F1 10 Tf 0 0 0 rg ( \() Tj /F3 10 Tf 0 0 0 rg (arg1) Tj /F1 10 Tf 0 0 0 rg (, ) Tj /F3 10 Tf 0 0 0 rg (arg2) Tj /F1 10 Tf 0 0 0 rg (\)) Tj T* ET
 Q
 Q
 q
@@ -847,7 +843,7 @@ endstream
 endobj
 51 0 obj
 <<
-/Length 3038
+/Length 3143
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -936,11 +932,17 @@ Q
 q
 1 0 0 1 40.01575 581.4394 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (namespaced::theclass::method \(C++ function\)) Tj 0 0 0 rg ( ) Tj 0 0 .501961 rg ([1]) Tj  T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (namespaced::theclass::method \(C++ function\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 551.0394 cm
+1 0 0 1 40.01575 563.4394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (namespaced::theclass::method2 \(C++ function\)) Tj  T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 533.0394 cm
 q
 .8 .8 .8 RG
 .3 w
@@ -953,13 +955,13 @@ BT 1 0 0 1 0 2.4 Tm /F7 12 Tf 14.4 TL (O) Tj T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 533.0394 cm
+1 0 0 1 40.01575 515.0394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (operator bool \(C++ function\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 502.6394 cm
+1 0 0 1 40.01575 484.6394 cm
 q
 .8 .8 .8 RG
 .3 w
@@ -972,13 +974,13 @@ BT 1 0 0 1 0 2.4 Tm /F7 12 Tf 14.4 TL (P) Tj T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 484.6394 cm
+1 0 0 1 40.01575 466.6394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (parrot \(module\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 454.2394 cm
+1 0 0 1 40.01575 436.2394 cm
 q
 .8 .8 .8 RG
 .3 w
@@ -991,13 +993,13 @@ BT 1 0 0 1 0 2.4 Tm /F7 12 Tf 14.4 TL (S) Tj T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 436.2394 cm
+1 0 0 1 40.01575 418.2394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (spam\(\) \(in module parrot\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 405.8394 cm
+1 0 0 1 40.01575 387.8394 cm
 q
 .8 .8 .8 RG
 .3 w
@@ -1010,22 +1012,22 @@ BT 1 0 0 1 0 2.4 Tm /F7 12 Tf 14.4 TL (T) Tj T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 387.8394 cm
+1 0 0 1 40.01575 369.8394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (theclass::const_iterator \(C++ type\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 369.8394 cm
+1 0 0 1 40.01575 351.8394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (theclass::name \(C++ member\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 369.8394 cm
+1 0 0 1 40.01575 351.8394 cm
 Q
 q
-1 0 0 1 40.01575 369.8394 cm
+1 0 0 1 40.01575 351.8394 cm
 Q
  
 endstream
@@ -1201,22 +1203,22 @@ xref
 0000007251 00000 n 
 0000008190 00000 n 
 0000008315 00000 n 
-0000009675 00000 n 
-0000009800 00000 n 
-0000017003 00000 n 
-0000017128 00000 n 
-0000020218 00000 n 
-0000020343 00000 n 
-0000021199 00000 n 
-0000021315 00000 n 
-0000021349 00000 n 
-0000021383 00000 n 
-0000021417 00000 n 
-0000021451 00000 n 
-0000021485 00000 n 
-0000021519 00000 n 
-0000021553 00000 n 
-0000021587 00000 n 
+0000009615 00000 n 
+0000009740 00000 n 
+0000016944 00000 n 
+0000017069 00000 n 
+0000020264 00000 n 
+0000020389 00000 n 
+0000021245 00000 n 
+0000021361 00000 n 
+0000021395 00000 n 
+0000021429 00000 n 
+0000021463 00000 n 
+0000021497 00000 n 
+0000021531 00000 n 
+0000021565 00000 n 
+0000021599 00000 n 
+0000021633 00000 n 
 trailer
 <<
 /ID 
@@ -1228,7 +1230,7 @@ trailer
 /Size 64
 >>
 startxref
-21621
+21667
 %%EOF
 %PDF-1.4
 %“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
@@ -1390,37 +1392,37 @@ endobj
 endobj
 26 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 699.0394 0 ] /Rect [ 40.01575 581.4394 244.5557 593.4394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 729.0394 0 ] /Rect [ 40.01575 581.4394 244.5557 593.4394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 27 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 729.0394 0 ] /Rect [ 247.3357 581.4394 258.4557 593.4394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 699.0394 0 ] /Rect [ 40.01575 563.4394 250.1157 575.4394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 28 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 639.0394 0 ] /Rect [ 40.01575 533.0394 165.0757 545.0394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 639.0394 0 ] /Rect [ 40.01575 515.0394 165.0757 527.0394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 29 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 435.0394 0 ] /Rect [ 40.01575 484.6394 108.3657 496.6394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 435.0394 0 ] /Rect [ 40.01575 466.6394 108.3657 478.6394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 30 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 435.0394 0 ] /Rect [ 40.01575 436.2394 152.8157 448.2394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 435.0394 0 ] /Rect [ 40.01575 418.2394 152.8157 430.2394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 31 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 573.0394 0 ] /Rect [ 40.01575 387.8394 192.8557 399.8394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 573.0394 0 ] /Rect [ 40.01575 369.8394 192.8557 381.8394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 32 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 573.0394 0 ] /Rect [ 40.01575 369.8394 175.0557 381.8394 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 20 0 R /XYZ 50.01575 573.0394 0 ] /Rect [ 40.01575 351.8394 175.0557 363.8394 ] /Subtype /Link /Type /Annot
 >>
 endobj
 33 0 obj
@@ -1574,7 +1576,7 @@ endstream
 endobj
 47 0 obj
 <<
-/Length 1308
+/Length 1248
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -1604,7 +1606,6 @@ q
 1 0 0 1 443.2441 57 cm
 q
 0 0 .501961 rg
-0 0 .501961 RG
 BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (1) Tj T* -66.44 0 Td ET
 Q
 Q
@@ -1618,7 +1619,6 @@ q
 1 0 0 1 443.2441 39 cm
 q
 0 0 .501961 rg
-0 0 .501961 RG
 BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (1) Tj T* -66.44 0 Td ET
 Q
 Q
@@ -1632,7 +1632,6 @@ q
 1 0 0 1 443.2441 21 cm
 q
 0 0 .501961 rg
-0 0 .501961 RG
 BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (3) Tj T* -66.44 0 Td ET
 Q
 Q
@@ -1646,7 +1645,6 @@ q
 1 0 0 1 443.2441 3 cm
 q
 0 0 .501961 rg
-0 0 .501961 RG
 BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (5) Tj T* -66.44 0 Td ET
 Q
 Q
@@ -1676,7 +1674,7 @@ endstream
 endobj
 49 0 obj
 <<
-/Length 7151
+/Length 7152
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -1720,7 +1718,7 @@ Q
 q
 1 0 0 1 40.01575 697.0394 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (bool ) Tj /F3 10 Tf 0 0 0 rg (namespaced::theclass::) Tj /F4 10 Tf 0 0 0 rg (method) Tj /F1 10 Tf 0 0 0 rg ( \() Tj /F3 10 Tf 0 0 0 rg (arg1) Tj /F1 10 Tf 0 0 0 rg (, ) Tj /F3 10 Tf 0 0 0 rg (arg2) Tj /F1 10 Tf 0 0 0 rg (\)) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (bool ) Tj /F3 10 Tf 0 0 0 rg (namespaced::theclass::) Tj /F4 10 Tf 0 0 0 rg (method2) Tj /F1 10 Tf 0 0 0 rg ( \() Tj /F3 10 Tf 0 0 0 rg (arg1) Tj /F1 10 Tf 0 0 0 rg (, ) Tj /F3 10 Tf 0 0 0 rg (arg2) Tj /F1 10 Tf 0 0 0 rg (\)) Tj T* ET
 Q
 Q
 q
@@ -2079,7 +2077,7 @@ endstream
 endobj
 51 0 obj
 <<
-/Length 3038
+/Length 3143
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -2168,11 +2166,17 @@ Q
 q
 1 0 0 1 40.01575 581.4394 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (namespaced::theclass::method \(C++ function\)) Tj 0 0 0 rg ( ) Tj 0 0 .501961 rg ([1]) Tj  T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (namespaced::theclass::method \(C++ function\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 551.0394 cm
+1 0 0 1 40.01575 563.4394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (namespaced::theclass::method2 \(C++ function\)) Tj  T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 533.0394 cm
 q
 .8 .8 .8 RG
 .3 w
@@ -2185,13 +2189,13 @@ BT 1 0 0 1 0 2.4 Tm /F7 12 Tf 14.4 TL (O) Tj T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 533.0394 cm
+1 0 0 1 40.01575 515.0394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (operator bool \(C++ function\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 502.6394 cm
+1 0 0 1 40.01575 484.6394 cm
 q
 .8 .8 .8 RG
 .3 w
@@ -2204,13 +2208,13 @@ BT 1 0 0 1 0 2.4 Tm /F7 12 Tf 14.4 TL (P) Tj T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 484.6394 cm
+1 0 0 1 40.01575 466.6394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (parrot \(module\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 454.2394 cm
+1 0 0 1 40.01575 436.2394 cm
 q
 .8 .8 .8 RG
 .3 w
@@ -2223,13 +2227,13 @@ BT 1 0 0 1 0 2.4 Tm /F7 12 Tf 14.4 TL (S) Tj T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 436.2394 cm
+1 0 0 1 40.01575 418.2394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (spam\(\) \(in module parrot\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 405.8394 cm
+1 0 0 1 40.01575 387.8394 cm
 q
 .8 .8 .8 RG
 .3 w
@@ -2242,22 +2246,22 @@ BT 1 0 0 1 0 2.4 Tm /F7 12 Tf 14.4 TL (T) Tj T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 387.8394 cm
+1 0 0 1 40.01575 369.8394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (theclass::const_iterator \(C++ type\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 369.8394 cm
+1 0 0 1 40.01575 351.8394 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (theclass::name \(C++ member\)) Tj  T* ET
 Q
 Q
 q
-1 0 0 1 40.01575 369.8394 cm
+1 0 0 1 40.01575 351.8394 cm
 Q
 q
-1 0 0 1 40.01575 369.8394 cm
+1 0 0 1 40.01575 351.8394 cm
 Q
  
 endstream
@@ -2433,22 +2437,22 @@ xref
 0000007251 00000 n 
 0000008190 00000 n 
 0000008315 00000 n 
-0000009675 00000 n 
-0000009800 00000 n 
-0000017003 00000 n 
-0000017128 00000 n 
-0000020218 00000 n 
-0000020343 00000 n 
-0000021199 00000 n 
-0000021315 00000 n 
-0000021349 00000 n 
-0000021383 00000 n 
-0000021417 00000 n 
-0000021451 00000 n 
-0000021485 00000 n 
-0000021519 00000 n 
-0000021553 00000 n 
-0000021587 00000 n 
+0000009615 00000 n 
+0000009740 00000 n 
+0000016944 00000 n 
+0000017069 00000 n 
+0000020264 00000 n 
+0000020389 00000 n 
+0000021245 00000 n 
+0000021361 00000 n 
+0000021395 00000 n 
+0000021429 00000 n 
+0000021463 00000 n 
+0000021497 00000 n 
+0000021531 00000 n 
+0000021565 00000 n 
+0000021599 00000 n 
+0000021633 00000 n 
 trailer
 <<
 /ID 
@@ -2460,5 +2464,5 @@ trailer
 /Size 64
 >>
 startxref
-21621
+21667
 %%EOF

--- a/rst2pdf/tests/reference/test_raw_html.pdf
+++ b/rst2pdf/tests/reference/test_raw_html.pdf
@@ -17,33 +17,47 @@ endobj
 endobj
 4 0 obj
 <<
-/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/A <<
+/S /URI /Type /Action /URI (mailto:pedro@address.es)
+>> /Border [ 0 0 0 ] /Rect [ 304.6378 732.5979 358.6918 740.4729 ] /Subtype /Link /Type /Annot
 >>
 endobj
 5 0 obj
 <<
-/Outlines 9 0 R /PageLabels 10 0 R /PageMode /UseNone /Pages 7 0 R /Type /Catalog
+/A <<
+/S /URI /Type /Action /URI (mailto:dimitr@mail.es)
+>> /Border [ 0 0 0 ] /Rect [ 304.6378 714.5979 358.0985 722.4729 ] /Subtype /Link /Type /Annot
 >>
 endobj
 6 0 obj
+<<
+/Annots [ 4 0 R 5 0 R ] /Contents 10 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageLabels 11 0 R /PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
 <<
 /Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
   /Subject (\(unspecified\)) /Title () /Trapped /False
 >>
 endobj
-7 0 obj
+9 0 obj
 <<
-/Count 1 /Kids [ 4 0 R ] /Type /Pages
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
 >>
 endobj
-8 0 obj
+10 0 obj
 <<
-/Length 1073
+/Length 1471
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -93,10 +107,38 @@ BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Pedro) Tj T* ET
 Q
 Q
 q
+1 0 0 1 240.9449 23.125 cm
+q
+1 0 0 1 1 -1 cm
+q
+.492188 w
+0 0 1 RG
+n 0 5.121125 m 54.054 5.121125 l S
+BT 1 0 0 1 0 6.1055 Tm 7.875 TL /F1 5.25 Tf 0 0 1 rg (pedro@mailaddress.es) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
 1 0 0 1 6 3 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Dimitri) Tj T* ET
+Q
+Q
+q
+1 0 0 1 240.9449 5.125 cm
+q
+1 0 0 1 1 -1 cm
+q
+.492188 w
+0 0 1 RG
+n 0 5.121125 m 53.46075 5.121125 l S
+BT 1 0 0 1 0 6.1055 Tm 7.875 TL /F1 5.25 Tf 0 0 1 rg (dimitr@mailaddress.es) Tj T* ET
+Q
+Q
+q
 Q
 Q
 q
@@ -119,45 +161,41 @@ Q
  
 endstream
 endobj
-9 0 obj
-<<
-/Count 0 /Type /Outlines
->>
-endobj
-10 0 obj
-<<
-/Nums [ 0 11 0 R ]
->>
-endobj
 11 0 obj
+<<
+/Nums [ 0 12 0 R ]
+>>
+endobj
+12 0 obj
 <<
 /S /D /St 1
 >>
 endobj
 xref
-0 12
+0 13
 0000000000 65535 f 
 0000000073 00000 n 
 0000000114 00000 n 
 0000000221 00000 n 
 0000000333 00000 n 
-0000000536 00000 n 
-0000000639 00000 n 
-0000000896 00000 n 
-0000000955 00000 n 
-0000002079 00000 n 
-0000002125 00000 n 
-0000002166 00000 n 
+0000000508 00000 n 
+0000000681 00000 n 
+0000000909 00000 n 
+0000000996 00000 n 
+0000001253 00000 n 
+0000001312 00000 n 
+0000002835 00000 n 
+0000002876 00000 n 
 trailer
 <<
 /ID 
 [<2db82f8d13fc9aad0f6ac8c1445975f3><2db82f8d13fc9aad0f6ac8c1445975f3>]
 % ReportLab generated PDF document -- digest (http://www.reportlab.com)
 
-/Info 6 0 R
-/Root 5 0 R
-/Size 12
+/Info 8 0 R
+/Root 7 0 R
+/Size 13
 >>
 startxref
-2200
+2910
 %%EOF

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ except ImportError:
     install_requires.append('simplejson')
 
 tests_require = ['pyPdf2']
-sphinx_require = ['sphinx']
+sphinx_require = ['sphinx<1.8.0']
 hyphenation_require = ['wordaxe>=1.0']
 images_require = ['pillow']
 pdfimages_require = ['pyPdf2','PythonMagick']


### PR DESCRIPTION
This picks up an update to urllib3 which had a security issue prior to 1.23.

(also updates ReportLab to 3.5.12, but this doesn't seem to be a problem!)

Can only upgrade Sphinx to 1.7.9 because 1.8+ causes failures (See #721 & #722)