### PR TITLE
Support visiting unknown nodes in SectNumFolder and SectRefExpander

### DIFF
--- a/rst2pdf/sectnumlinks.py
+++ b/rst2pdf/sectnumlinks.py
@@ -9,6 +9,9 @@ class SectNumFolder(docutils.nodes.SparseNodeVisitor):
         for i in node.parent.parent['ids']:
             self.sectnums[i]=node.parent.astext().replace(u'\xa0\xa0\xa0',' ')
 
+    def unknown_visit(self, node):
+        pass
+
 class SectRefExpander(docutils.nodes.SparseNodeVisitor):
     def __init__(self, document, sectnums):
         docutils.nodes.SparseNodeVisitor.__init__(self, document)
@@ -17,3 +20,6 @@ class SectRefExpander(docutils.nodes.SparseNodeVisitor):
     def visit_reference(self, node):
         if node.get('refid', None) in self.sectnums:
             node.children=[docutils.nodes.Text('%s '%self.sectnums[node.get('refid')])]
+
+    def unknown_visit(self, node):
+        pass


### PR DESCRIPTION
This should fix #727 at least in the sense of rst2pdf not crashing.

However, I am not sure if it will behave "correctly", please use it and let me know of any broken bits.