### PR TITLE
Prepare for 0.94

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ rst2pdf/tests/input/*/_build
 .vscode/
 .python-version
 .venv/
+dist/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,9 @@
 {next}
 ------
 
+{0.94 2019-01-12}
+-----------------
+
 * Sphinx config setting pdf_invariant works properly now (Issue #718)
 * Updated reportlab dependency to 3.5.12 and Sphinx to 1.7.9 (Issue #718)
 * Updated reportlab dependency to 3.5.10 (Issue #714)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 {next}
 ------
 
-{0.94 2019-01-12}
------------------
+0.94 2019-01-17
+---------------
 
 * Added: ``:hl_lines:`` code directive allows highlighting of specific lines (Issue #623)
 * Added: ``repeat_table_rows`` is now supported in Sphinx (Issue #505)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,32 +5,35 @@
 {0.94 2019-01-12}
 -----------------
 
-* Sphinx config setting pdf_invariant works properly now (Issue #718)
-* Updated reportlab dependency to 3.5.12 and Sphinx to 1.7.9 (Issue #718)
-* Updated reportlab dependency to 3.5.10 (Issue #714)
-* Fixed handling of empty documents, they now generate a single empty page (Issue 547)
-* Fix handling of non-http/ftp URLs (Issue #549)
-* Do not use logging.basicConfig (Issue 509)
-* Removed Tenjin and switched to Jinja2 (Issue #696)
-* Made literal block shrinking work again (Issue #560)
-* Removed copy of smartypants, use PyPI package instead (Issue 694)
-* Fixed bug in token replacement that broke tables in headers/footers (Issue 612)
-* Added: ``:hl_lines:`` code directive allows highlighting of specific lines (issue 623)
-* Added: Extension metadata for Sphinx is now returned in pdfbuilder (issue 640)
+* Added: ``:hl_lines:`` code directive allows highlighting of specific lines (Issue #623)
+* Added: ``repeat_table_rows`` is now supported in Sphinx (Issue #505)
+* Added: ``scale_width`` is now supported for ``--fit-background-mode`` (Issue #505)
+* Added: Extension metadata for Sphinx is now returned in pdfbuilder (Issue 640)
 * Added: The Sphinx ``today`` config setting is now used if it is set
 * Changed: ``:start-after:`` will now render the next line
+* Changed: Updated reportlab dependency to 3.5.12 and Sphinx to 1.7.9 (Issue #718)
+* Changed: We no longer logging.basicConfig configuration (Issue #509)
 * Changed: We now use PILLOW rather than PIL
-* Fixed: Using ``:start-after:`` with ``linenos_offset`` now displays the correct line number
-* Fixed: Using ``:start-at:`` with ``linenos_offset`` now displays the correct line number
-* Fixed: Inline ``:math:`` works again as we now use quoted attributes for HTML ``<img>`` tags (issue 567)
-* Fixed: sphinx+rst2pdf now works with automodule directive Sphinx >= 1.4 (issue 566)
-* Fixed: CreationDate metadata shows correct date using Sphinx (issue 525)
+* Fixed bug in token replacement that broke tables in headers/footers (Issue #612)
+* Fixed handling of empty documents, they now generate a single empty page (Issue #547)
 * Fixed: ``:alt:`` option now works for plantuml extension
 * Fixed: ``:linenos_offset:`` now works again
+* Fixed: `rst2pdf.createpdf.main` now releases the input file handle
+* Fixed: CreationDate metadata shows correct date using Sphinx (Issue #525)
+* Fixed: Error when using --date-invariant with newer reportlab versions (Issue #678)
+* Fixed: handling of non-http/ftp URLs (Issue #549)
+* Fixed: Inline ``:math:`` works again as we now use quoted attributes for HTML ``<img>`` tags (Issue 567)
+* Fixed: Made literal block shrinking work again (Issue #560)
 * Fixed: Removed debugging print statement when using line blocks
-* Fixed: Removed uniconverter from setup (issue 487)
-* Fixed: Error when using --date-invariant with newer reportlab versions (Issue 678)
-
+* Fixed: Removed uniconverter from setup (Issue #487)
+* Fixed: Renamed links now work (Issue #569)
+* Fixed: Sphinx config setting pdf_invariant works properly now (Issue #718)
+* Fixed: sphinx+rst2pdf now works with automodule directive Sphinx >= 1.4 (Issue #566)
+* Fixed: Using ``:start-after:`` with ``linenos_offset`` now displays the correct line number
+* Fixed: Using ``:start-at:`` with ``linenos_offset`` now displays the correct line number
+* Removed: Our own copy of smartypants. We now use the PyPI package instead (Issue #694)
+* Removed: Tenjin has been switched to Jinja2 (Issue #696)
+* Removed: The QT4 GUI is no more (Issue #690)
 
 0.93 (2012-12-18)
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ library.
 
 More information is available `at the main website`__
 
-__ http://rst2pdf.github.io
+__ https://rst2pdf.org
 
 Features
 ========
@@ -35,7 +35,7 @@ Features
 
 * `Full user's manual`__
 
-__ http://ralsina.me/static/manual.pdf
+__ https://rst2pdf.org/static/manual.pdf
 
 Installation and use
 ====================

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-rst2pdf: Use a text editor.  Make a PDF.
+rst2pdf: Use a text editor. Make a PDF.
 ========================================
 
 The usual way of creating PDF from reStructuredText is by going through LaTeX.
@@ -43,8 +43,8 @@ Installation and use
 Install from PyPI
 -----------------
 
-The latest released version, 0.94, may be installed from PyPI by using
-pip or easy_install.  It does not support Python 3::
+The latest released version may be installed from PyPI by using
+pip or easy_install. It does not support Python 3::
 
   sudo pip install rst2pdf
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Intro
-=====
+rst2pdf: Use a text editor.  Make a PDF.
+========================================
 
 The usual way of creating PDF from reStructuredText is by going through LaTeX.
 This tool provides an alternative by producing PDF directly using the ReportLab

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Installation and use
 Install from PyPI
 -----------------
 
-The latest released version, 0.93, may be installed from PyPI by using
+The latest released version, 0.94, may be installed from PyPI by using
 pip or easy_install.  It does not support Python 3::
 
   sudo pip install rst2pdf

--- a/doc/RELEASE_PROCESS.rst
+++ b/doc/RELEASE_PROCESS.rst
@@ -3,31 +3,51 @@ Release Process for rst2pdf
 
 This is an outline of what needs to be done in order to release rst2pdf.
 
-1. Update version number in setup.py
-2. Update CHANGES.rst
+1. Update version number in ``setup.py``
+2. Update ``CHANGES.rst``
 3. Update version number and revision in manual
-4. Build manual and upload to HTML and PDF to the website
-   via a PR on the rst2pdf.github.io repo.
-5. Ensure all PRs are attached to the milestone
-6. Close the milestone and create next one
-7. Use changelog-generator_ (or similar) to create a changelog
-8. Tag release with version number
-9. Update Releases section on GitHub project and paste in changelog
-10. Create rc1 distribution package
+4. Build manual
+
+   ::
+
+     $ cd doc; ./gen_docs.sh
+
+   Add subject and autor to manual PDF's meta data using ExifTool_
+
+   ::
+
+     $ exiftool -PDF:Subject="v0.94 r2019011700" output/pdf/manual.pdf
+     $ exiftool -PDF:Author="rst2pdf project; Roberto Alsina" output/pdf/manual.pdf
+
+   and upload to HTML and PDF to the website
+   via a PR on the rst2pdf.github.io_ repo.
+
+6. Ensure all PRs are attached to the milestone
+7. Close the milestone and create next one
+8. Use changelog-generator_ (or similar) to create a changelog
+9. Tag release with version number
+
+   ::
+
+      $ git tag -s 0.94
+      $ git push upstream 0.94
+
+10. Update Releases section on GitHub project and paste in changelog
+11. Create rc distribution package
 
     ::
 
        $ python setup.py egg_info -b "rc1" sdist bdist_wheel
 
-    If you're doing an alphaX, betaX or postX, then change ``-b ""`` to ``-b "RC1"`` (or whatever)
+    If you're doing an alphaX, betaX or postX, then change ``-b "rc1"`` appropriately
 
-11. Upload rc1 to Test-PyPI_
+11. Upload the rc distribution to Test-PyPI_
 
     ::
 
        $ twine upload --repository testpypi dist/*
 
-    Check that it all looks correct on TestPyPI. If not, fix and release a new rc.
+    Check that it all looks correct on Test-PyPI. If not, fix and release a new rc.
 
 12. Test Test-PyPI release into a clean virtual env
 
@@ -45,7 +65,8 @@ This is an outline of what needs to be done in order to release rst2pdf.
        $ python setup.py egg_info -b "" sdist bdist_wheel
        $ twine upload --repository pypi dist/*
 
-
+|
+|
 
 *Note:* create a ``~/.pypirc`` file to make the ``--repository`` switch work with ``twine``.
 It should contain the following:
@@ -61,9 +82,12 @@ It should contain the following:
 
 
 
+.. _ExifTool: https://www.sno.phy.queensu.ca/~phil/exiftool/
+.. _rst2pdf.github.io: https://github.com/rst2pdf/rst2pdf.github.io
 .. _changelog-generator: https://github.com/weierophinney/changelog_generator
 .. _Test-PyPI: https://test.pypi.org
 .. _PyPI: https://test.pypi.org
+
 
 
 

--- a/doc/RELEASE_PROCESS.rst
+++ b/doc/RELEASE_PROCESS.rst
@@ -1,0 +1,70 @@
+Release Process for rst2pdf
+===========================
+
+This is an outline of what needs to be done in order to release rst2pdf.
+
+1. Update version number in setup.py
+2. Update CHANGES.rst
+3. Update version number and revision in manual
+4. Build manual and upload to HTML and PDF to the website
+   via a PR on the rst2pdf.github.io repo.
+5. Ensure all PRs are attached to the milestone
+6. Close the milestone and create next one
+7. Use changelog-generator_ (or similar) to create a changelog
+8. Tag release with version number
+9. Update Releases section on GitHub project and paste in changelog
+10. Create rc1 distribution package
+
+    ::
+
+       $ python setup.py egg_info -b "rc1" sdist bdist_wheel
+
+    If you're doing an alphaX, betaX or postX, then change ``-b ""`` to ``-b "RC1"`` (or whatever)
+
+11. Upload rc1 to Test-PyPI_
+
+    ::
+
+       $ twine upload --repository testpypi dist/*
+
+    Check that it all looks correct on TestPyPI. If not, fix and release a new rc.
+
+12. Test Test-PyPI release into a clean virtual env
+
+    ::
+
+       $ pip install --index-url https://test.pypi.org/simple \
+         --extra-index-url https://pypi.org/simple rst2pdf
+
+    It should install and be able to create PDF documents from rst files
+
+13. Once rc version is working, release to PyPI_ by generating official release and uploading
+
+    ::
+
+       $ python setup.py egg_info -b "" sdist bdist_wheel
+       $ twine upload --repository pypi dist/*
+
+
+
+*Note:* create a ``~/.pypirc`` file to make the ``--repository`` switch work with ``twine``.
+It should contain the following:
+
+::
+
+   [pypi]
+   username: {your PyPi username}
+
+   [testpypi]
+   repository: https://test.pypi.org/legacy/
+   username: {your PyPi username}
+
+
+
+.. _changelog-generator: https://github.com/weierophinney/changelog_generator
+.. _Test-PyPI: https://test.pypi.org
+.. _PyPI: https://test.pypi.org
+
+
+
+

--- a/doc/assets/cover.tmpl
+++ b/doc/assets/cover.tmpl
@@ -9,7 +9,7 @@
 
 .. class:: centered
 
-Version 0.90
+Version 0.94
 
 .. raw:: pdf
 

--- a/doc/assets/manual.css
+++ b/doc/assets/manual.css
@@ -100,3 +100,12 @@ code, tt {
 kbd {
   color: #101010;
 }
+
+.auto-toc {
+  list-style-type: none;
+  list-style: none;
+}
+
+.toc-root > ul {
+  padding-left: 10px;
+}

--- a/doc/assets/manual.css
+++ b/doc/assets/manual.css
@@ -4,8 +4,6 @@ Based on ``blue_box.css`` by Ian Bicking
 and ``html4css1.css`` revision 1.46.
 */
 
-@import url(html4css1.css);
-
 body {
   font-family: 'Lucida Grande', 'Calibri', Helvetica, Arial, sans-serif;
 }

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2,9 +2,10 @@
 How to use rst2pdf
 ==================
 
-:author: Roberto Alsina <ralsina@netmanagers.com.ar>
-:version: 0.93
-:revision: $LastChangedRevision$
+.. meta::
+  :authors: rst2pdf project <https://rst2pdf.org>; Roberto Alsina <ralsina@netmanagers.com.ar>;
+  :version: 0.94
+  :revision: 2019011700
 
 .. header::
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -16,7 +16,7 @@ How to use rst2pdf
       +---+---------------------+----------------+
       |   |.. class:: centered  |.. class:: right|
       |   |                     |                |
-      |   |Section ###Section###|Page ###Page### |
+      |   |        ###Section###|Page ###Page### |
       +---+---------------------+----------------+
 
       .. class:: headertable
@@ -24,11 +24,12 @@ How to use rst2pdf
       +---------------+---------------------+---+
       |               |.. class:: centered  |   |
       |               |                     |   |
-      |Page ###Page###|Section ###Section###|   |
+      |Page ###Page###|        ###Section###|   |
       +---------------+---------------------+---+
 
 
 .. contents::
+  :class: toc-root
 
 .. section-numbering::
 

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,6 @@ aafigure
 docutils
 matplotlib
 pdfrw
-pillow
 pygments
 pyPdf2
 reportlab

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,8 @@ pillow
 pygments
 pyPdf2
 reportlab
-sphinx
+six
+smartypants
+sphinx<1.80
 svg2rlg
 xhtml2pdf
-smartypants

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ matplotlib==2.2.3
 numpy==1.15.4             # via matplotlib
 packaging==18.0           # via sphinx
 pdfrw==0.4
-pillow==5.3.0
+pillow==5.3.0             # via reportlab, xhtml2pdf
 pygments==2.3.0
 pyparsing==2.3.0          # via matplotlib, packaging
 pypdf2==1.26.0
@@ -30,7 +30,7 @@ python-dateutil==2.7.5    # via matplotlib
 pytz==2018.7              # via babel, matplotlib
 reportlab==3.5.12
 requests==2.21.0          # via sphinx
-six==1.12.0               # via cycler, html5lib, matplotlib, packaging, python-dateutil, sphinx, xhtml2pdf
+six==1.12.0
 smartypants==2.0.1
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.7.9
@@ -40,9 +40,4 @@ svg2rlg==0.3
 typing==3.6.6             # via sphinx
 urllib3==1.24.1           # via requests
 webencodings==0.5.1       # via html5lib
-smartypants==2.0.1
 xhtml2pdf==0.2.3
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip                       # via reportlab
-# setuptools                # via html5lib, reportlab, sphinx

--- a/rst2pdf/extensions/dotted_toc.py
+++ b/rst2pdf/extensions/dotted_toc.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
 # See LICENSE.txt for licensing terms
-#$HeadURL$
-#$LastChangedDate$
-#$LastChangedRevision$
 
 # Some fragments of code are copied from Reportlab under this license:
 #

--- a/rst2pdf/tests/execmgr.py
+++ b/rst2pdf/tests/execmgr.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-#$HeadURL$
-#$LastChangedDate$
-#$LastChangedRevision$
-
 # See LICENSE.txt for licensing terms
 
 '''

--- a/rst2pdf/tests/htmllog.py
+++ b/rst2pdf/tests/htmllog.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#$HeadURL: https://rst2pdf.googlecode.com/svn/trunk/rst2pdf/tests/parselogs.py $
-#$LastChangedDate: 2010-03-07 21:25:16 -0600 (Sun, 07 Mar 2010) $
-#$LastChangedRevision: 1730 $
-
 # See LICENSE.txt for licensing terms
 
 '''

--- a/rst2pdf/tests/parselogs.py
+++ b/rst2pdf/tests/parselogs.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#$HeadURL$
-#$LastChangedDate$
-#$LastChangedRevision$
-
 # See LICENSE.txt for licensing terms
 
 '''

--- a/rst2pdf/tests/setmd5.py
+++ b/rst2pdf/tests/setmd5.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#$HeadURL$
-#$LastChangedDate$
-#$LastChangedRevision$
-
-
 '''
 Copyright (c) 2009, Patrick Maupin, Austin, Texas
 

--- a/rst2pdf/tests/zinspector12.py
+++ b/rst2pdf/tests/zinspector12.py
@@ -1,10 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#$HeadURL$
-#$LastChangedDate$
-#$LastChangedRevision$
-
 # See LICENSE.txt for licensing terms
 
 '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,2 @@
 [egg_info]
 tag_build = .dev
-tag_svn_revision = true

--- a/setup.py
+++ b/setup.py
@@ -17,36 +17,15 @@ if sys.version_info[0] > 2:
     sys.stderr.write('rst2pdf is python2-only for now.')
     exit(1)
 
-long_description = (
-    read('LICENSE.txt')
-    + '\n' +
-    'Detailed Documentation\n'
-    '**********************\n'
-    + '\n' +
-    read('README.rst')
-    + '\n' +
-    'Contributors\n'
-    '************\n'
-
-
-    + '\n' +
-    read('Contributors.txt')
-    + '\n' +
-    'Change history\n'
-    '**************\n'
-    + '\n' +
-    read('CHANGES.rst')
-    + '\n' +
-   'Download\n'
-    '********\n'
-    )
+long_description = read('README.rst')
 
 install_requires = [
         'setuptools',
         'docutils',
-        'reportlab>=2.4',
-        'Pygments',
         'pdfrw',
+        'pygments',
+        'reportlab',
+        'smartypants',
         ]
 
 try:
@@ -68,6 +47,7 @@ rawhtmlsupport_require = ['xhtml2pdf']
 setup(
     name="rst2pdf",
     version=version,
+    python_requires='~=2.7',
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     package_data=dict(rst2pdf=['styles/*.json',
 	'styles/*.style',
@@ -97,23 +77,27 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
-        'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python:: 2',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Topic :: Documentation',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Processing',
         'Topic :: Utilities',
     ],
-    author="Roberto Alsina",
-    author_email="ralsina at netmanagers dot com dot ar",
-    description="Convert restructured text to PDF via reportlab.",
+    author="rst2pdf maintainers",
+    author_email="maintainers@rstpdf.org",
+    description="Convert reStructured Text to PDF via ReportLab.",
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     license="MIT",
     keywords="restructured convert rst pdf docutils pygments reportlab",
     url="https://rst2pdf.org",
+    project_urls={
+        'Bug Reports': 'https://github.com/rst2pdf/rst2pdf/issues',
+        'Source': 'https://github.com/rst2pdf/rst2pdf',
+    },
     download_url="https://github.com/rst2pdf/rst2pdf/releases",
     entry_points={'console_scripts': ['rst2pdf = rst2pdf.createpdf:main']},
     test_suite='rst2pdf.tests.test_rst2pdf.test_suite',  # TODO: this needs to be updated

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,14 @@ if sys.version_info[0] > 2:
 long_description = read('README.rst')
 
 install_requires = [
-        'setuptools',
         'docutils',
         'pdfrw',
         'pygments',
         'reportlab',
+        'setuptools',
+        'six',
         'smartypants',
+        'jinja2',
         ]
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
     long_description=long_description,
     license="MIT",
     keywords="restructured convert rst pdf docutils pygments reportlab",
-    url="http://rst2pdf.github.io",
+    url="https://rst2pdf.org",
     download_url="https://github.com/rst2pdf/rst2pdf/releases",
     entry_points={'console_scripts': ['rst2pdf = rst2pdf.createpdf:main']},
     test_suite='rst2pdf.tests.test_rst2pdf.test_suite',  # TODO: this needs to be updated

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-version = '0.93'
+version = '0.94'
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,13 @@ long_description = read('README.rst')
 
 install_requires = [
         'docutils',
+        'jinja2',
         'pdfrw',
         'pygments',
         'reportlab',
         'setuptools',
         'six',
         'smartypants',
-        'jinja2',
         ]
 
 try:
@@ -38,7 +38,6 @@ except ImportError:
 tests_require = ['pyPdf2']
 sphinx_require = ['sphinx<1.8.0']
 hyphenation_require = ['wordaxe>=1.0']
-images_require = ['pillow']
 pdfimages_require = ['pyPdf2','PythonMagick']
 pdfimages2_require = ['pyPdf2','SWFTools']
 svgsupport_require = ['svg2rlg']
@@ -66,7 +65,6 @@ setup(
         tests=tests_require,
         sphinx=sphinx_require,
         hyphenation=hyphenation_require,
-        images=images_require,
         pdfimages=pdfimages_require,
         pdfimages2=pdfimages2_require,
         svgsupport=svgsupport_require,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-#$HeadURL$
-#$LastChangedDate$
-#$LastChangedRevision$
 
 import os
 import sys


### PR DESCRIPTION
Updates for releasing rst2pdf 0.94.

I've set up a test at https://test.pypi.org/project/rst2pdf

You can test the version on _Test PyPI_ using: 

```
$ pip install --index-url https://test.pypi.org/simple/ \
    --extra-index-url https://pypi.org/simple rst2pdf
```

Items complete:

* Improved _long_description_ so that's it's more friendly on PyPI
* Remove `tag_svn_revision` as it's obsolete
* Added _six_ and _smartypants_ as dependencies in `setup.py` so that it works in a clean Python environment
* Remove Pillow dependency as it's provided by ReportLab now
* Updated `requirements.in` & `requirements.txt`
* Updated the project's url to rst2pdf.org
* Updated setup.py's author and author email to be generic as it must be a valid email when creating a dist file
* Updated the version number - the date'll in Changes.rst will need updating upon release.
* @ralsina has sorted out @akrabat's PyPI permissions
* Ensure `CHANGES.rst` covers all changes
* Merge @lornajane's manual building PR
* Update manual version number
* Check manual metadata such as URLs and email addresses, etc. 
* Create a `release-process.rst` document explaining how to do a release so we don't have to re-learn for next time…

Items to do:

* Release 0.94!