### PR TITLE
New hash for fancytitles test

### DIFF
--- a/rst2pdf/tests/md5/test_fancytitles.json
+++ b/rst2pdf/tests/md5/test_fancytitles.json
@@ -5,8 +5,8 @@ bad_md5 = [
 ]
 
 good_md5 = [
-        'd3026a17fc7eada374a140c85e8fea99',
         '5386e164e5a952f88980a1089cf92fee',
+        '651349f0143b26986707ef8a374a4d2b',
         '73165f457eba4d815ae058cea34b652b',
         '83470d0795d86a50c85337bc3ee015f6',
         '851de582dc29f82f490622d197ba229b',
@@ -16,6 +16,7 @@ good_md5 = [
         'bcada59a905c2b719254eb936cad0d24',
         'cff6d1519da3a90d4523e7be5c0a749c',
         'd0a24c172a8603ead539bb47a347ab65',
+        'd3026a17fc7eada374a140c85e8fea99',
         'd934858d3b72c113fa6134a4c2f8dede',
         'f1151ed4005455a522620dd156a7e79a',
         'sentinel'


### PR DESCRIPTION
This was the only failing test on my system and I was missing a canberra module of some kind. The output is visually identical to what I find in the references directory so I think this hash should be acceptable, the new dependency may well be causing the different hash.