### PR TITLE
Convert Code of Conduct to Markdown

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,22 +1,18 @@
-rst2pdf Community Code of Conduct
-=================================
+# rst2pdf Community Code of Conduct
 
 The rst2pdf community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, we encourage you to follow these guidelines which help steer our interactions and strive to keep rst2pdf a positive, successful, and growing community.
 
 A member of the rst2pdf community is:
 
-Open
-----
+## Open
 
 Members of the community are open to collaboration, whether it's on patches, problems, or otherwise. We're receptive to constructive comment and criticism, as the experiences and skill sets of other members contribute to the whole of our efforts. We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.
 
-Considerate
------------
+## Considerate
 
 Members of the community are considerate of their peers -- other rst2pdf users and developers. We're thoughtful when addressing the efforts of others, keeping in mind that often times the labor was completed simply for the good of the community. We're attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
 
-Respectful
-----------
+## Respectful
 
 Members of the community are respectful. We're respectful of others, their positions, their skills, their commitments, and their efforts. We're respectful of the volunteer efforts that permeate the rst2pdf community. We're respectful of the processes set forth in the community, and we work within them. When we disagree, we are courteous in raising our issues.
 


### PR DESCRIPTION
It turns out that GitHub doesn't recognise that the project doesn't have a CoC unless it's named `CODE_OF_CONDUCT.md`…