### PR TITLE
Update version to 0.95.dev

### DIFF
--- a/doc/assets/cover.tmpl
+++ b/doc/assets/cover.tmpl
@@ -9,7 +9,7 @@
 
 .. class:: centered
 
-Version 0.94
+Version 0.95.dev
 
 .. raw:: pdf
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4,7 +4,7 @@ How to use rst2pdf
 
 .. meta::
   :authors: rst2pdf project <https://rst2pdf.org>; Roberto Alsina <ralsina@netmanagers.com.ar>;
-  :version: 0.94
+  :version: 0.95.dev
   :revision: 2019011700
 
 .. header::

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-version = '0.94'
+version = '0.95'
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()


### PR DESCRIPTION
This will help us understand whether a bug report is from a pip install
or from latest source.

i.e. after this change, the latest source version will be:

```
$ rst2pdf --version
0.95.dev0
```
