### PR TITLE
Decode output of fc-match in Python2 as UTF-8

### DIFF
--- a/rst2pdf/findfonts.py
+++ b/rst2pdf/findfonts.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 import six
 
 import os
+import subprocess
 import sys
 
 from reportlab.pdfbase import pdfmetrics
@@ -181,7 +182,7 @@ def findFont(fname):
 def findTTFont(fname):
 
     def get_family(query):
-        data = os.popen("fc-match \"%s\""%query, "r").read()
+        data = subprocess.check_output(["fc-match", query])
         if six.PY2:
             data = data.decode('UTF-8')
         for line in data.splitlines():
@@ -195,7 +196,7 @@ def findTTFont(fname):
         return None
 
     def get_fname(query):
-        data = os.popen("fc-match -v \"%s\""%query, "r").read()
+        data = subprocess.check_output(["fc-match", "-v", query])
         if six.PY2:
             data = data.decode('UTF-8')
         for line in data.splitlines():

--- a/rst2pdf/findfonts.py
+++ b/rst2pdf/findfonts.py
@@ -8,6 +8,7 @@ then create rst2pdf-ready font-aliases.
 """
 
 from __future__ import unicode_literals
+import six
 
 import os
 import sys
@@ -181,6 +182,8 @@ def findTTFont(fname):
 
     def get_family(query):
         data = os.popen("fc-match \"%s\""%query, "r").read()
+        if six.PY2:
+            data = data.decode('UTF-8')
         for line in data.splitlines():
             line = line.strip()
             if not line:
@@ -193,6 +196,8 @@ def findTTFont(fname):
 
     def get_fname(query):
         data = os.popen("fc-match -v \"%s\""%query, "r").read()
+        if six.PY2:
+            data = data.decode('UTF-8')
         for line in data.splitlines():
             line = line.strip()
             if line.startswith("file: "):


### PR DESCRIPTION
If the output of fc-match contains any unicode characters, then we need to handle this in Python 2.

Fixes #757