### PR TITLE
Fixed reportlab import

### DIFF
--- a/rst2pdf/flowables.py
+++ b/rst2pdf/flowables.py
@@ -4,7 +4,7 @@
 __docformat__ = 'reStructuredText'
 
 from copy import copy
-import re
+import reportlab
 
 from reportlab.platypus import *
 from reportlab.platypus.doctemplate import *


### PR DESCRIPTION
**Describe the bug**
When running html generation I ended up with the error:

```
Exception occurred:
File "/usr/local/lib/python2.7/dist-packages/rst2pdf/flowables.py", line 895, in <module>
   if reportlab.Version == '2.1':
 NameError: name 'reportlab' is not defined
```

**To Reproduce**
Steps to reproduce the behavior:
```
sphinx-build -b html -d stage/doctrees   source/welcome stage/html
```