### PR TITLE
Import reportlab into flowables.py

### DIFF
--- a/rst2pdf/flowables.py
+++ b/rst2pdf/flowables.py
@@ -8,6 +8,7 @@ __docformat__ = 'reStructuredText'
 
 from copy import copy
 import re
+import reportlab
 
 from reportlab.platypus import *
 from reportlab.platypus.doctemplate import *


### PR DESCRIPTION
This fixes #771 for 0.94.x as it's breaking on latest ReportLab and will allow us to release 0.94.1 with just this fix in it.

I've also created a `0.94.x` branch from the `0.94` tag in order to give us somewhere to release 0.94.1 from.