### PR TITLE
Fix internal links so that they work with latest ReportLab

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 {next}
 ------
 
+* Fixed: Internal links work when using ReportLab 3.5.19+ (Issue #772)
 * Add support for units in spaceBefore/spaceAfter for stylesheets (Issue #754)
 * Remove support for Psyco (Issue #756)
 * Remove support for PythonMagick, GFX and SWFTools (Issue #756)

--- a/rst2pdf/flowables.py
+++ b/rst2pdf/flowables.py
@@ -1013,7 +1013,7 @@ class MyTableOfContents(TableOfContents):
                 leftColStyle = self.levelStyles[left_col_level]
             label = self.refid_lut.get((level, text, pageNum), None)
             if label:
-                pre = u'<a href="%s" color="%s">' % (label, self.linkColor)
+                pre = u'<a href="#%s" color="%s">' % (label, self.linkColor)
                 post = u'</a>'
                 if isinstance(text, bytes):
                     text = text.decode('utf-8')

--- a/rst2pdf/genelements.py
+++ b/rst2pdf/genelements.py
@@ -822,7 +822,7 @@ class HandleFootnote(NodeHandler, docutils.nodes.footnote,
                 client.targets.append(ltext)
         elif len(node['backrefs'])==1 and client.footnote_backlinks:
             if ltext not in client.targets:
-                label = Paragraph(ids+'<a href="%s" color="%s">%s</a>' % (
+                label = Paragraph(ids+'<a href="#%s" color="%s">%s</a>' % (
                                     node['backrefs'][0],
                                     client.styles.linkColor,
                                     ltext), client.styles["endnote"])


### PR DESCRIPTION
Prior to ReportLab 3.5.19, a link that wasn't well-formed was assumed to
be an internal anchor. This was [fixed][1] in 3.5.19, so we now need to
prefix all internal links we generate with `#`.

This fixes #772 

[1]: https://bitbucket.org/rptlab/reportlab/commits/c46115a85b61f4822026e72f5949a4fb1b63ba73


### To Test:

Given `test.rst`:

```rst
===============================
Document with Table of Contents
===============================


.. contents:: Table of Contents
   :depth: 2

Heading 1
=========

Normal, **Bold**, *Italic*.

This is a paragraph in Page 1 [#]_

.. [#] This is a footnote in page 1
```

Run:

```
rst2pdf test.rst
```

Open the resulting `test.pdf` and resize into a vertically narrow window and ensure that 

* The TOC link takes you to the _Heading 1_ section 
* The footnote at the end of the paragraph takes you to the footnote
* The link in the footnote takes you back the paragraph

Test with ReportLab 3.5.12 and then update ReportLab to the latest, rebuild and test again.