### PR TITLE
Update LICENSE copyright to reference all contributors

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,4 @@
-Copyright (c) 2007,2008,2009 Roberto Alsina
-Nicolas Laurance, Christoph Zwerschke, Yasushi Masuda, Josh VanderLinden.
-
+Copyright (c) 2007-2019 Roberto Alsina and the contributors to the rst2pdf project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Rather than list all copyright holders in the license file directly, we now reference them as the "contributors to the rst2pdf project".

The full list of contributors is available via `git shortlog -sn` or via https://github.com/rst2pdf/rst2pdf/graphs/contributors.

This addresses issue #768