### PR TITLE
Fix image retrieval over urlretrieve + svg import errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 {next}
 ------
 
+* Fixed: HTTPS images using image directive now works with Python 3 (Issue #780)
 * Changed: Update tested dependencies to include ReportLab 3.5.23 (Issue #779)
 * Fixed: Internal links work when using ReportLab 3.5.19+ (Issue #772)
 * Add support for units in spaceBefore/spaceAfter for stylesheets (Issue #754)

--- a/rst2pdf/image.py
+++ b/rst2pdf/image.py
@@ -19,7 +19,11 @@ else:
 from .opt_imports import PILImage, pdfinfo
 from .log import log, nodeid
 
-from .svgimage import SVGImage
+try:
+    from .svgimage import SVGImage
+except ModuleNotFoundError:
+    # svglib may optionally not be installed, which causes this error
+    pass
 
 # This assignment could be overridden by an extension module
 VectorPdf = None

--- a/rst2pdf/image.py
+++ b/rst2pdf/image.py
@@ -8,7 +8,13 @@ import tempfile
 from copy import copy
 from reportlab.platypus.flowables import Image, Flowable
 from reportlab.lib.units import *
-import urllib
+
+import six
+
+if six.PY3:
+    from urllib.request import urlretrieve
+else:
+    from urllib import urlretrieve
 
 from .opt_imports import PILImage, pdfinfo
 from .log import log, nodeid
@@ -78,7 +84,7 @@ class MyImage (Flowable):
 
         if filename.split("://")[0].lower() in ('http','ftp','https'):
             try:
-                filename2, _ = urllib.urlretrieve(filename)
+                filename2, _ = urlretrieve(filename)
                 if filename != filename2:
                     client.to_unlink.append(filename2)
                     filename = filename2
@@ -219,7 +225,7 @@ class MyImage (Flowable):
         if uri.split("://")[0].lower() not in ('http','ftp','https'):
             uri = os.path.join(client.basedir,uri)
         else:
-            uri, _ = urllib.urlretrieve(uri)
+            uri, _ = urlretrieve(uri)
             client.to_unlink.append(uri)
 
         srcinfo = client, uri

--- a/rst2pdf/image.py
+++ b/rst2pdf/image.py
@@ -19,6 +19,8 @@ else:
 from .opt_imports import PILImage, pdfinfo
 from .log import log, nodeid
 
+from .svgimage import SVGImage
+
 # This assignment could be overridden by an extension module
 VectorPdf = None
 
@@ -197,7 +199,6 @@ class MyImage (Flowable):
 
         if extension in ['svg','svgz']:
             log.info('Backend for %s is SVGIMage'%filename)
-            from .svgimage import SVGImage
             backend=SVGImage
 
         elif extension in ['pdf']:
@@ -251,7 +252,6 @@ class MyImage (Flowable):
         xdpi, ydpi = client.styles.def_dpi, client.styles.def_dpi
         extension = imgname.split('.')[-1].lower()
         if extension in ['svg','svgz']:
-            from .svgimage import SVGImage
             iw, ih = SVGImage(imgname, srcinfo=srcinfo).wrap(0, 0)
             # These are in pt, so convert to px
             iw = iw * xdpi / 72

--- a/rst2pdf/image.py
+++ b/rst2pdf/image.py
@@ -13,8 +13,6 @@ import urllib
 from .opt_imports import PILImage, pdfinfo
 from .log import log, nodeid
 
-from .svgimage import SVGImage
-
 # This assignment could be overridden by an extension module
 VectorPdf = None
 
@@ -193,6 +191,7 @@ class MyImage (Flowable):
 
         if extension in ['svg','svgz']:
             log.info('Backend for %s is SVGIMage'%filename)
+            from .svgimage import SVGImage
             backend=SVGImage
 
         elif extension in ['pdf']:
@@ -246,6 +245,7 @@ class MyImage (Flowable):
         xdpi, ydpi = client.styles.def_dpi, client.styles.def_dpi
         extension = imgname.split('.')[-1].lower()
         if extension in ['svg','svgz']:
+            from .svgimage import SVGImage
             iw, ih = SVGImage(imgname, srcinfo=srcinfo).wrap(0, 0)
             # These are in pt, so convert to px
             iw = iw * xdpi / 72

--- a/rst2pdf/tests/md5/test_fancytitles.json
+++ b/rst2pdf/tests/md5/test_fancytitles.json
@@ -5,8 +5,6 @@ bad_md5 = [
 ]
 
 good_md5 = [
-        'b96b278b6cec29d579b12576b22e60b6',
-        'a77136a819c03f358dfffdbddaea5a81',
         '3ddba1b9358cf7972e8eb0d52372bac2',
         '5386e164e5a952f88980a1089cf92fee',
         '651349f0143b26986707ef8a374a4d2b',
@@ -17,11 +15,14 @@ good_md5 = [
         '9e88380a0925626642824537227d848e',
         'a217398fa299ae19259fbcaf41f8e585',
         'a29a17c9d3b73d20209b424d95ae922d',
+        'a77136a819c03f358dfffdbddaea5a81',
+        'b96b278b6cec29d579b12576b22e60b6',
         'bcada59a905c2b719254eb936cad0d24',
         'cff6d1519da3a90d4523e7be5c0a749c',
         'd0a24c172a8603ead539bb47a347ab65',
         'd3026a17fc7eada374a140c85e8fea99',
         'd934858d3b72c113fa6134a4c2f8dede',
+        'e69efcc26486b9bdf980f592583e26bc',
         'f1151ed4005455a522620dd156a7e79a',
         'sentinel'
 ]


### PR DESCRIPTION
Resolves https://github.com/rst2pdf/rst2pdf/issues/780 and a new svg-related issue.

I followed the same six-related pattern found throughout createpdf.py, genpdftext.py, and pdfbuilder.py.

## SVG-related issue

SVG image support is currently optional. By importing the svgimage module at the top of the image.py module, any rst document that contained an image relied on having svglib installed, whether or not that image were an svg. This PR fixes that problem. :tada: 