### PR TITLE
Sphinx3 compatibility fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 {next}
 ------
 
+* Fixed: Support Sphinx 2.1+ on Python 3 (Issue #788)
 * Changed: Support docutils math directive instead of rst2pdf's (Issue #722)
 * Fixed: HTTPS images using image directive now works with Python 3 (Issue #780)
 * Changed: Update tested dependencies to include ReportLab 3.5.23 (Issue #779)
@@ -35,7 +36,7 @@
 * Fixed handling of empty documents, they now generate a single empty page (Issue #547)
 * Fixed: ``:alt:`` option now works for plantuml extension
 * Fixed: ``:linenos_offset:`` now works again
-* Fixed: `rst2pdf.createpdf.main` now releases the input file handle
+* Fixed: ``rst2pdf.createpdf.main`` now releases the input file handle
 * Fixed: CreationDate metadata shows correct date using Sphinx (Issue #525)
 * Fixed: Error when using --date-invariant with newer reportlab versions (Issue #678)
 * Fixed: handling of non-http/ftp URLs (Issue #549)

--- a/rst2pdf/dumpstyle.py
+++ b/rst2pdf/dumpstyle.py
@@ -144,7 +144,7 @@ def fixstyle(obj):
 def convert(srcname):
     ''' Convert a single file from .json to .style
     '''
-    print srcname
+    print(srcname)
     sstr = open(srcname, 'rb').read()
     sdata = fixstyle(jloads(sstr))
     dstr = dumps(sdata)

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -26,6 +26,7 @@ else:
 import re
 import sys
 import os
+import time
 from os import path
 from os.path import abspath, dirname, expanduser, join
 from pprint import pprint
@@ -53,8 +54,7 @@ from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.util.console import darkgreen, red
 from sphinx.util import SEP
-from sphinx.util import ustrftime
-from sphinx.environment import NoUri
+from sphinx.errors import NoUri
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.locale import admonitionlabels, versionlabels
 if sphinx.__version__ >= '1.':
@@ -592,7 +592,7 @@ class PDFWriter(writers.Writer):
             if self.config.today :
                 date = self.config.today
             else:
-                date=ustrftime(self.config.today_fmt or _('%B %d, %Y'))
+                date=time.strftime(self.config.today_fmt or _('%B %d, %Y'))
 
             # Feed data to the template, get restructured text.
             cover_text = template.render(

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -54,7 +54,11 @@ from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.util.console import darkgreen, red
 from sphinx.util import SEP
-from sphinx.errors import NoUri
+if sphinx.__version__ >= '2.1':
+    from sphinx.errors import NoUri
+else:
+    from sphinx.environment import NoUri
+
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.locale import admonitionlabels, versionlabels
 if sphinx.__version__ >= '1.':


### PR DESCRIPTION
NoUri was moved under sphinx.errors
ustrftime is deprecated, used time.strftime instead