### PR TITLE
Make it still work with Python 2

### DIFF
--- a/rst2pdf/image.py
+++ b/rst2pdf/image.py
@@ -21,7 +21,7 @@ from .log import log, nodeid
 
 try:
     from .svgimage import SVGImage
-except ModuleNotFoundError:
+except ImportError:
     # svglib may optionally not be installed, which causes this error
     pass
 


### PR DESCRIPTION
Unless difference between Import Error and Module Not Found Error is that important for SVGImage import.