### PR TITLE
Fix for fonts in Windows

### DIFF
--- a/rst2pdf/findfonts.py
+++ b/rst2pdf/findfonts.py
@@ -222,7 +222,7 @@ def findTTFont(fname):
         # ctypes with EnumFontFamiliesEx
 
         def get_nt_fname(ftname):
-            import _winreg as _w
+            import winreg as _w
 
             fontkey = _w.OpenKey(
                 _w.HKEY_LOCAL_MACHINE,

--- a/rst2pdf/findfonts.py
+++ b/rst2pdf/findfonts.py
@@ -222,7 +222,10 @@ def findTTFont(fname):
         # ctypes with EnumFontFamiliesEx
 
         def get_nt_fname(ftname):
-            import winreg as _w
+            if six.PY3:
+                import winreg as _w
+            else:
+                import _winreg as _w            
 
             fontkey = _w.OpenKey(
                 _w.HKEY_LOCAL_MACHINE,


### PR DESCRIPTION
This was enough to make pdfbuilder work with Sphinx 2.2.0 in Windows 10.

Fixes #806 

![it_aint_much](https://user-images.githubusercontent.com/9550197/65715716-ed770b80-e09d-11e9-9556-ed14f23933fb.jpg)
