### PR TITLE
Ignore Sphinx _build files created when testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ rst2pdf/tests/output/*.log
 .python-version
 .venv/
 dist/
+_build/
+


### PR DESCRIPTION
The Sphinx tests generate an _build directory that I don't believe we need, so add `_build` to `.gitignore`.