### PR TITLE
First pass at adding snap support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: rst2pdf
+base: core18 
+adopt-info: rst2pdf
+summary: Use a text editor. Make a PDF.
+description: |
+  The usual way of creating PDF from reStructuredText is by going through
+  LaTeX. This tool provides an alternative by producing PDF directly using
+  the ReportLab library.
+
+grade: stable
+confinement: strict
+
+parts:
+  rst2pdf:
+    plugin: python
+    python-version: python2
+    source: .
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version $(git describe --tags)
+
+apps:
+  rst2pdf:
+    command: rst2pdf
+    plugs:
+      - home
+      - removable-media
+      - network


### PR DESCRIPTION
Fixes #743 

Once (if) merged, I recommend someone from the project registers an account at snapcraft.io (link top right) and then visit build.snapcraft.io, hook it up (big green button) to this git repo. That should build you a snap and publish to the store for multiple architectures. 