### PR TITLE
Allow code-block language to be optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 ------
 
 * Add support for Inkscape 1.x in the inkscape extension (Issue #821)
+* Fixed: Allow the code-block's language attribute to be optional (Issue #819)
 * Fixed: Add Python 3.6 and 3.7 to the setup file  (Issue #814)
 * Fixed: Support the preprocess extension on Python 3 (Issue #811)
 * Fixed: Fix findfonts on Windows in Python 3 (Issue #807)

--- a/rst2pdf/pygments_code_block_directive.py
+++ b/rst2pdf/pygments_code_block_directive.py
@@ -240,7 +240,11 @@ def code_block_directive(name, arguments, options, content, lineno,
     if not "linenos_offset" in options:
         line_offset = 0
 
-    language = arguments[0]
+    try:
+        language = arguments[0]
+    except IndexError:
+        language = 'text'
+
     # create a literal block element and set class argument
     code_block = nodes.literal_block(classes=["code", language])
 
@@ -350,7 +354,7 @@ def raw_compress(argument):
 # ------------------
 # ::
 
-code_block_directive.arguments = (1, 0, 1)
+code_block_directive.arguments = (0, 1, 1)
 code_block_directive.content = 1
 code_block_directive.options = {'include': directives.unchanged_required,
                                 'start-at': directives.unchanged_required,

--- a/rst2pdf/tests/input/test_no_language_set_on_code_block.txt
+++ b/rst2pdf/tests/input/test_no_language_set_on_code_block.txt
@@ -1,0 +1,11 @@
+No language
+===========
+
+This test checks that the language attribute of a code-block does not cause an errror when it is not supplied.
+
+To pass, there should be no errors on the command line and the code block below should be styled as plain text.
+
+.. code-block::
+
+    This is a code block with no language specified as the language is optional
+    as per https://docutils.sourceforge.io/docs/ref/rst/directives.html#code

--- a/rst2pdf/tests/md5/test_no_language_set_on_code_block.json
+++ b/rst2pdf/tests/md5/test_no_language_set_on_code_block.json
@@ -1,0 +1,17 @@
+bad_md5 = [
+        'sentinel'
+]
+
+good_md5 = [
+        'ec93e332912c6b9d7d3df3b9e1eb49e0',
+        'sentinel'
+]
+
+incomplete_md5 = [
+        'sentinel'
+]
+
+unknown_md5 = [
+        'sentinel'
+]
+

--- a/rst2pdf/tests/reference/test_no_language_set_on_code_block.pdf
+++ b/rst2pdf/tests/reference/test_no_language_set_on_code_block.pdf
@@ -1,0 +1,135 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageLabels 10 0 R /PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (No language) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 1 /Kids [ 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Length 1014
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 741.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 4 Tm /F2 20 Tf 24 TL 174.9349 0 Td (No language) Tj T* -174.9349 0 Td ET
+Q
+Q
+q
+1 0 0 1 62.69291 707.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 1.987765 Tw 12 TL /F1 10 Tf 0 0 0 rg (This test checks that the language attribute of a code-block does not cause an errror when it is not) Tj T* 0 Tw (supplied.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 677.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .917882 Tw (To pass, there should be no errors on the command line and the code block below should be styled as) Tj T* 0 Tw (plain text.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 631.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 36 re B*
+Q
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F3 10 Tf 12 TL (This is a code block with no language specified as the language is optional) Tj T* (as per https://docutils.sourceforge.io/docs/ref/rst/directives.html#code) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+ 
+endstream
+endobj
+10 0 obj
+<<
+/Nums [ 0 11 0 R ]
+>>
+endobj
+11 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000448 00000 n 
+0000000651 00000 n 
+0000000738 00000 n 
+0000001006 00000 n 
+0000001065 00000 n 
+0000002130 00000 n 
+0000002171 00000 n 
+trailer
+<<
+/ID 
+[<b2a3834ddf32f807fb0226badfa0b7de><b2a3834ddf32f807fb0226badfa0b7de>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 12
+>>
+startxref
+2205
+%%EOF


### PR DESCRIPTION
As per the rST specification[1] allow the code-block directive's language argument to be optional.

Fixes #819

1: https://docutils.sourceforge.io/docs/ref/rst/directives.html#code