### PR TITLE
Update dumpstyle.py

### DIFF
--- a/rst2pdf/dumpstyle.py
+++ b/rst2pdf/dumpstyle.py
@@ -13,6 +13,11 @@ import os
 from .rson import loads as rloads
 from json import loads as jloads
 
+try:
+    basestring # py27
+except:
+    basestring = str # Py3+
+
 def dumps(obj, forcestyledict=True):
     ''' If forcestyledict is True, will attempt to
         turn styles into a dictionary.

--- a/rst2pdf/dumpstyle.py
+++ b/rst2pdf/dumpstyle.py
@@ -6,10 +6,11 @@
     to .style in the styles directory.
 '''
 
+from __future__ import absolute_import
 import sys
 import os
 
-from rson import loads as rloads
+from .rson import loads as rloads
 from json import loads as jloads
 
 def dumps(obj, forcestyledict=True):
@@ -155,7 +156,8 @@ def convert(srcname):
     dstf.write(dstr)
     dstf.close()
 
-
 if __name__ == '__main__':
-    for fname in [os.path.join('styles', x) for x in os.listdir('styles') if x.endswith('.json')]:
+    _dir =  os.path.dirname(sys.argv[0])
+    _stylesdir = os.path.join(_dir, 'styles')
+    for fname in [os.path.join('styles', x) for x in os.listdir(_stylesdir) if x.endswith('.json')]:
         convert(fname)

--- a/rst2pdf/pygments2style.py
+++ b/rst2pdf/pygments2style.py
@@ -4,9 +4,10 @@
 Creates a rst2pdf stylesheet for each pygments style.
 '''
 
+from __future__ import absolute_import
 import sys
 import os
-import dumpstyle
+from . import dumpstyle
 from pygments.token import STANDARD_TYPES
 from pygments import styles as pstyles
 


### PR DESCRIPTION
Added from __future__ import absolute_import, and adjusted import statement for Py2-3 compatibility.

Corrected directory location in __main__ routine to be relative to rst2pdf package (os.path.listdir('styles') wouldn't work if we weren't running from the right directory).