### PR TITLE
Update master version to 0.96.dev

### DIFF
--- a/doc/assets/cover.tmpl
+++ b/doc/assets/cover.tmpl
@@ -9,7 +9,7 @@
 
 .. class:: centered
 
-Version 0.95.dev
+Version 0.96.dev
 
 .. raw:: pdf
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4,7 +4,7 @@ How to use rst2pdf
 
 .. meta::
   :authors: rst2pdf project <https://rst2pdf.org>; Roberto Alsina <ralsina@netmanagers.com.ar>;
-  :version: 0.95.dev
+  :version: 0.96.dev
   :revision: 2019011700
 
 .. header::

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-version = '0.96.dev'
+version = '0.96'
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-version = '0.95'
+version = '0.96.dev'
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()


### PR DESCRIPTION
With 0.95 released, we update the code to 0.96.dev so that we can distinguish a bug reported against the master branch from one against the 0.95 release.