### PR TITLE
Add support for publishing rst2pdf as a snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ rst2pdf/tests/output/*.log
 .python-version
 .venv/
 dist/
+snap/.snapcraft

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,14 @@ The latest released version may be installed from PyPI by using
 
     $ pip install --user rst2pdf
 
+Install from Snap
+~~~~~~~~~~~~~~~~~
+
+If you are using a system that supports [snaps](https://snapcraft.io/)
+then you can install from there with::
+
+    $ snap install rst2pdf
+
 Install from GitHub
 ~~~~~~~~~~~~~~~~~~~
 

--- a/doc/RELEASE_PROCESS.rst
+++ b/doc/RELEASE_PROCESS.rst
@@ -87,3 +87,13 @@ It should contain the following:
 .. _changelog-generator: https://github.com/weierophinney/changelog_generator
 .. _Test-PyPI: https://test.pypi.org
 .. _PyPI: https://test.pypi.org
+
+
+Releasing as a Snap
+~~~~~~~~~~~~~~~~~~~
+
+1. Update the version string in ``snap/snapcraft.yml`` as desired (probably to match the new release tag)
+
+2. Run ``snapcraft`` and note the filename of the output
+
+3. Now publish (the ``rst2pdf`` namespace is associated with @lornajane's Ubuntu account) by doing ``snapcraft push --release=stable [the snape filename from the previous step]``

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,11 +1,13 @@
 name: rst2pdf
 base: core18 
-adopt-info: rst2pdf
+version: '0.96'
 summary: Use a text editor. Make a PDF.
 description: |
-  The usual way of creating PDF from reStructuredText is by going through
-  LaTeX. This tool provides an alternative by producing PDF directly using
-  the ReportLab library.
+  Create PDF reports, slide decks and other documents from the command line using **rst2pdf**.
+
+  With simple ReStructured Text format, a stylesheet of your choosing, and rst2pdf, creating PDFs is fast and easy. The familiarity of your favorite text editor, the separation of the presentation layer from your content, and the simplicity of running a single command to get the PDF output will make rst2pdf an excellent tool for your day-to-day use.
+
+  Python and ReportLab power this open source project; find out more at https://rst2pdf.org.
 
 grade: stable
 confinement: strict
@@ -14,11 +16,6 @@ parts:
   rst2pdf:
     plugin: python
     source: .
-    build-packages:
-      - git # needed for the version trick
-    override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version $(git describe --tags)
 
 apps:
   rst2pdf:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,8 +13,9 @@ confinement: strict
 parts:
   rst2pdf:
     plugin: python
-    python-version: python2
     source: .
+    build-packages:
+      - git # needed for the version trick
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version $(git describe --tags)
@@ -26,3 +27,4 @@ apps:
       - home
       - removable-media
       - network
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: rst2pdf
+base: core18 
+adopt-info: rst2pdf
+summary: Use a text editor. Make a PDF.
+description: |
+  The usual way of creating PDF from reStructuredText is by going through
+  LaTeX. This tool provides an alternative by producing PDF directly using
+  the ReportLab library.
+
+grade: stable
+confinement: strict
+
+parts:
+  rst2pdf:
+    plugin: python
+    python-version: python2
+    source: .
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version $(git describe --tags)
+
+apps:
+  rst2pdf:
+    command: rst2pdf
+    plugs:
+      - home
+      - removable-media
+      - network


### PR DESCRIPTION
Fixes #743 and replaces #816 (because I couldn't work out how to push back to that remote when I added some updates).

@popey made us a snap configuration! I've updated it now we're on python 3 and tested it locally. I'm now in the market for other snap users to test this as well and let us know how they get on. We don't yet have access to the reserved `rst2pdf` name on snapcraft.io but once I hear from @ralsina if it's not him that has it registered I'll request it and work towards releasing this as an official install channel for this project.

To test this if you are a snap user (the process is a bit different for installing a local snap than a proper published one):
- run `snapcraft` in the root of the project to pick up the snapcraft file and build the snap
- run `sudo snap install [the snap file you just made] --dangerous` the dangerous flag indicates you know you're installing unsigned random code package!
- now try the rst2pdf command and you should get a pdf file output :) If you already have an rst2pdf install, then at least on ubuntu the new executable will be in `/snap/bin/rst2pdf` and you can use that directly.