### PR TITLE
Fix manual

### DIFF
--- a/doc/DEVELOPERS.rst
+++ b/doc/DEVELOPERS.rst
@@ -1,13 +1,11 @@
-===========================
+---------------------------
 Help for rst2pdf developers
-===========================
+---------------------------
 
------------------------------
 Or, how do I hack this thing?
------------------------------
 
 Guidelines
-----------
+~~~~~~~~~~
 
 In rst2pdf we want many things. We want ponies and icecream. But most of all,
 we want rst2pdf to kick ass. The best way to achieve that is making rst2pdf
@@ -78,14 +76,14 @@ know what you are doing. It also means you don't break rst2pdf.
 
 
 Continuous Integration
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 There's a Travis build - see https://github.com/rst2pdf/rst2pdf/issues/621 for
 more information on the current status
 
 
 Running tests
--------------
+~~~~~~~~~~~~~
 
 The rst2pdf test suite generates PDFs, then calculates a checksum (an md5) of
 the resulting file and checks it against known lists of good and bad md5s.
@@ -93,7 +91,7 @@ These known outcomes are in ``rst2pdf/tests/md5/[test_name].json`` (warning,
 not actually a JSON file).
 
 First run
-~~~~~~~~~
+*********
 
 To run the tests for the first time, you will need to do some setup (after
 this, you can just work on your given virtualenv each time)::
@@ -107,7 +105,7 @@ this, you can just work on your given virtualenv each time)::
     nosetests -v -i regulartest -i sphinxtest
 
 Next runs
-~~~~~~~~~
+*********
 
 While in project::
 
@@ -118,7 +116,7 @@ To stop the tests on the first failure, use the ``-x`` switch::
   nosetests -x -i regulartest -i sphinxtest
 
 Using autotest directly
-~~~~~~~~~~~~~~~~~~~~~~~
+***********************
 
 You can also run the tests using autorun directly::
 
@@ -129,7 +127,7 @@ You can also run the tests using autorun directly::
 Now look at the output of ``log.txt``
 
 Running a single test
-~~~~~~~~~~~~~~~~~~~~~
+*********************
 
 To run one test only, try this::
 
@@ -139,7 +137,7 @@ To run one test only, try this::
 This will run one test and show the output.
 
 Skipping tests
-~~~~~~~~~~~~~~
+**************
 
 To skip a test, simply create a text file in the ``tests/input`` directory
 called ``[test].ignore`` containing a note on why the test is skipped. This
@@ -148,7 +146,7 @@ for inherited tests that we aren't confident of the correct output for, but
 where we don't want to delete/lose the test entirely.
 
 Marking a failing test as good
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+******************************
 
 Sometimes the local combination of software versions will create the "right"
 PDF but the binary file will have some minor differences. If your file looks
@@ -164,7 +162,7 @@ explaining what you did.
 
 
 Getting commit rights
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 Just ask in the mailing list.
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -1886,7 +1886,7 @@ Developers
 ----------
 
 .. include:: DEVELOPERS.rst
-   :start-line: 8
+   :start-line: 4
 
 
 Licenses

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -279,7 +279,7 @@ size specified, rst2pdf will arbitrarily decide it should use 300DPI (or
 whatever you choose with the ``--default-dpi`` option).
 
 Styles
-~~~~~~
+------
 
 You can style paragraphs with a style using the class directive::
 
@@ -1058,7 +1058,7 @@ The code-block directive supports many options, that mirror Pygments'::
 You can find more information about them in the pygments manual.
 
 File inclusion
-**************
+~~~~~~~~~~~~~~
 
 You can use the ``code-block`` directive with an external file, using the
 ``:include:`` option::
@@ -1122,7 +1122,7 @@ Raw Directive
 -------------
 
 Raw PDF
-*******
+~~~~~~~
 
 rst2pdf has a very limited mechanism to pass commands to reportlab, the PDF
 generation library.  You can use the raw directive to insert pagebreaks and
@@ -1150,7 +1150,7 @@ The unit used by the spacer by default is points, and using a space or a comma
 is the same thing in all cases.
 
 Page Counters
-*************
+~~~~~~~~~~~~~
 
 In some documents, you may not want your page counter to start in the first
 page.
@@ -1191,7 +1191,7 @@ It can take zero or two arguments.
 .. note:: Page counter changes take effect on the **current** page.
 
 Page Breaks
-***********
+~~~~~~~~~~~
 
 There are three kinds of page breaks:
 
@@ -1210,7 +1210,7 @@ template. For example::
     PageBreak twoColumn
 
 Frame Breaks
-************
+~~~~~~~~~~~~
 
 If you want to jump to the next frame in the page (or the next page if the
 current frame is the last), you can use the ``FrameBreak`` command. It takes an
@@ -1228,7 +1228,7 @@ from the bottom of the frame::
     the page...
 
 Page Transitions
-****************
+~~~~~~~~~~~~~~~~
 
 Page transitions are effects used when you change pages in *Presentation* or
 *Full Screen* mode (depends on the viewer).  You can use it when creating a
@@ -1278,7 +1278,7 @@ next* so the natural thing is to use it before a ``PageBreak``::
        PageBreak
 
 Text Annotations
-****************
+~~~~~~~~~~~~~~~~
 
 Text annotations are meta notes added to a page.
 
@@ -1292,7 +1292,7 @@ The optional position is a set of 4 numbers for ``x_begin``, ``y_begin`,
 ``x_end`` and ``y_end``
 
 Raw HTML
-********
+~~~~~~~~
 
 If you have a document that contains raw HTML, and have ``xhtml2pdf`` installed,
 ``rst2pdf`` will try to render that HTML inside your document. To enable this,

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3,7 +3,7 @@ How to use rst2pdf
 ==================
 
 .. meta::
-  :authors: rst2pdf project <https://rst2pdf.org>; Roberto Alsina <ralsina@netmanagers.com.ar>;
+  :authors: rst2pdf project <https://rst2pdf.org>; Roberto Alsina <ralsina@netmanagers.com.ar>  and the contributors to the rst2pdf project;
   :version: 0.96.dev
   :revision: 2019011700
 
@@ -1894,9 +1894,7 @@ Licenses
 
 This is the license for rst2pdf::
 
-    Copyright (c) 2007,2008,2009 Roberto Alsina
-    Nicolas Laurance, Christoph Zwerschke, Yasushi Masuda, Josh VanderLinden,
-    Patrick Maupin.
+    Copyright (c) 2007-2019 Roberto Alsina and the contributors to the rst2pdf project
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/rst2pdf/extensions/dotted_toc.py
+++ b/rst2pdf/extensions/dotted_toc.py
@@ -53,8 +53,7 @@ Paragraph = genelements.Paragraph
 All I did was take the wrap() method from the stock reportlab TOC generator,
 and make the minimal changes to make it work on MY documents in rst2pdf.
 
-History:
-~~~~~~~~
+**History:**
 
 The reportlab TOC generator adds nice dots between the text and the page number.
 The rst2pdf one does not.
@@ -70,12 +69,12 @@ out if this is right, or how to support dots in the TOC in the main code.
 Mind you, the original RL implementation is a complete hack in any case:
 
 - It uses a callback to a nested function which doesn't even bother to
-    assume the original enclosing scope is available at callback time.
-    This leads it to do crazy things like eval()
+  assume the original enclosing scope is available at callback time.
+  This leads it to do crazy things like eval()
 
 - It uses a single name in the canvas for the callback function
-    (this is what kills multiple TOC capability) when it would be
-    extremely easy to generate a unique name.
+  (this is what kills multiple TOC capability) when it would be
+  extremely easy to generate a unique name.
 '''
 
 


### PR DESCRIPTION
The title levels in `manual.rst` are inconsistent and this is a fatal error in docutils. 

In addition, `DEVELOPERS.rst` is pulled into manual.rst, so the title levels in `DEVELOPERS.rst` need to be adjusted so that the sections within `DEVELOPERS.rst` sit within the chapter in manual.

Finally, the comment text in the extensions are also pulled into `manual.rst`, so the `dotted_toc` comment needed updating so that it didn't create a new chapter in the manual.

For reference when reviewing, the levels used by the manual are:

    level 1: ============
    level 2: ------------
    level 3: ~~~~~~~~~~~~
    level 4: ************
    level 5: """"""""""""


Fixes #833 