### PR TITLE
Fix PyPI links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,13 @@
     :target: https://travis-ci.org/rst2pdf/rst2pdf
 
 .. image:: https://img.shields.io/pypi/v/rst2pdf.svg
-    :target: https://pypi.python.org/pypi/rst2pdf/rst2pdf
+    :target: https://pypi.org/project/rst2pdf/
 
 .. image:: https://img.shields.io/pypi/pyversions/rst2pdf.svg
-    :target: https://pypi.python.org/pypi/rst2pdf/rst2pdf
+    :target: https://pypi.org/project/rst2pdf/
 
 .. image:: https://img.shields.io/pypi/l/rst2pdf.svg
-    :target: https://pypi.python.org/pypi/rst2pdf/rst2pdf
+    :target: https://pypi.org/project/rst2pdf/
 
 
 ========================================


### PR DESCRIPTION
The current links do not work.