### PR TITLE
Fix generation of source tarball

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 {next}
 ------
 
+* Fixed: The styles directory is now packaged with the release tarball. (Issue 857)
 * Fixed: Sphinx config settings pdf_real_footnotes and pdf_use_toc are now boolean. Note
   that value of pdf_real_footnotes is not False if not explicitly set. (Issue #846)
 * Changed: We have moved to pytest (Issue #850)

--- a/setup.py
+++ b/setup.py
@@ -41,13 +41,13 @@ setup(
     version=version,
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*',
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    package_dir={'': '.'},
     package_data=dict(rst2pdf=['styles/*.json',
 	'styles/*.style',
 	'images/*png',
 	'images/*jpg',
 	'templates/*tmpl'
 	]),
-    include_package_data=True,
     dependency_links=[
     ],
     install_requires=install_requires,


### PR DESCRIPTION
Without specifying the package_dir mapping, data belonging to the
rst2pdf package such as styles wouldn't install properly for my system.