### PR TITLE
Update Pillow to 6.2.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 {next}
 ------
 
+* Update Pillow dependency in requirements.txt. (Issue #858)
 * Fixed: The styles directory is now packaged with the release tarball. (Issue 857)
 * Fixed: Sphinx config settings pdf_real_footnotes and pdf_use_toc are now boolean. Note
   that value of pdf_real_footnotes is not False if not explicitly set. (Issue #846)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ matplotlib==2.2.4
 numpy==1.16.4             # via matplotlib
 packaging==19.0           # via sphinx
 pdfrw==0.4
-pillow==6.2.0             # via reportlab, xhtml2pdf
+pillow==6.2.2             # via reportlab, xhtml2pdf
 pygments==2.4.2
 pyparsing==2.4.0          # via matplotlib, packaging
 pypdf2==1.26.0


### PR DESCRIPTION
Addresses CVE-2019-19911 & CVE-2020-5313 as noted by Dependabot.