### PR TITLE
Add LICENSE, README and CHANGES to source tarball

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 
 * Changed: Use content-based comparison in tests. (Issue #854)
 * Changed: Inkscape 1.0 final supported properly and use path on Windows. (Issue #870)
+* Fixed: The README, LICENSE and CHANGES files are now packaged with the release tarball. (Issue 867)
 
 0.97 (2020-05-09)
 -----------------

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2007-2019 Roberto Alsina and the contributors to the rst2pdf project
+Copyright (c) 2007-2020 Roberto Alsina and the contributors to the rst2pdf project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.rst
+include LICENSE.txt
+include CHANGES.rst

--- a/doc/RELEASE_PROCESS.rst
+++ b/doc/RELEASE_PROCESS.rst
@@ -59,12 +59,25 @@ This is an outline of what needs to be done in order to release rst2pdf.
 
     It should install and be able to create PDF documents from rst files
 
+    Delete the build artifacts and dist files with:
+
+    ::
+
+        $ rm -rf build/ rst2pdf.egg-info/ dist/
+
 13. Once rc version is working, release to PyPI_ by generating official release and uploading
 
     ::
 
        $ python setup.py egg_info -b "" sdist bdist_wheel
        $ twine upload --repository pypi dist/*
+
+
+    Check that the release is correct on PyPI_ and then delete the build artifacts and dist files with:
+
+    ::
+
+        $ rm -rf build/ rst2pdf.egg-info/ dist/
 
 |
 |

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -1894,7 +1894,7 @@ Licenses
 
 This is the license for rst2pdf::
 
-    Copyright (c) 2007-2019 Roberto Alsina and the contributors to the rst2pdf project
+    Copyright (c) 2007-2020 Roberto Alsina and the contributors to the rst2pdf project
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
These files should be in the PyPI download. I've also updated the copyright year to 2020 in the license.

Fixes #866.