### PR TITLE
Stop ignoring generated SVGs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ __pycache__
 *.egg-info
 .coverage
 *.build_temp
-tmp*.svg
 log.txt
 rst2pdf/tests/output/*.pdf
 rst2pdf/tests/output/*.log


### PR DESCRIPTION
The presence of these in our input directory indicates a bug in how we're cleaning things up that we should resolve. They shouldn't be ignored.