### PR TITLE
Use correct argument to 'inkscape'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 {next}
 ------
 
-* Use content-based comparison in tests. (Issue #854)
-
+* Changed: Use content-based comparison in tests. (Issue #854)
+* Changed: Inkscape 1.0 final supported properly and use path on Windows. (Issue #870)
 
 0.97 (2020-05-09)
 -----------------

--- a/rst2pdf/extensions/inkscape_r2p.py
+++ b/rst2pdf/extensions/inkscape_r2p.py
@@ -69,11 +69,12 @@ class InkscapeImage(VectorPdf):
                 # Inkscape 0.x uses -A
                 cmd = [progname, os.path.abspath(filename), '-A', pdffname]
             else:
-                # Inkscape 1.x uses --export-file
+                # Inkscape 1.x uses --export-filename
                 cmd = [
                     progname,
                     os.path.abspath(filename),
-                    '--export-file=%s' % pdffname,
+                    '--export-filename',
+                    pdffname,
                 ]
             try:
                 result = subprocess.call(cmd)
@@ -119,11 +120,12 @@ class InkscapeImage(VectorPdf):
                     str(client.def_dpi),
                 ]
             else:
-                # Inkscape 1.x uses --export-file
+                # Inkscape 1.x uses --export-filename
                 cmd = [
                     progname,
                     os.path.abspath(filename),
-                    '--export-file=%s' % pngfname,
+                    '--export-filename',
+                    pngfname,
                     '-d',
                     str(client.def_dpi),
                 ]

--- a/rst2pdf/extensions/inkscape_r2p.py
+++ b/rst2pdf/extensions/inkscape_r2p.py
@@ -6,6 +6,9 @@ inkscape.py is an rst2pdf extension (e.g. rst2pdf -e inkscape xxx xxxx)
 which uses the inkscape program to convert an svg to a PDF, then uses
 the vectorpdf code to process the PDF.
 
+In order for this exention to work, you must ensure that inkscape is
+on your PATH.
+
 .. NOTE::
 
     The initial version is a proof of concept; uses subprocess in a naive way,


### PR DESCRIPTION
Per #869, inkscape 1.0 final uses '--export-filename' - not '--export-file'. This was causing test failures on Fedora 31.

While we're here, we take the opportunity to clean up this file, replacing some hardcoded paths on Windows and running the whole thing through black. We can do a lot more of the latter as we proceed with fixing various bugs and removing all the skipped tests.