### PR TITLE
Use 'pytest.fail' instead of 'assert' in test

### DIFF
--- a/rst2pdf/tests/conftest.py
+++ b/rst2pdf/tests/conftest.py
@@ -152,6 +152,14 @@ class Item(pytest.Item):
         output_file = os.path.join(OUTPUT_DIR, self.name + '.pdf')
         reference_file = os.path.join(REFERENCE_DIR, self.name + '.pdf')
 
+        if not os.path.exists(reference_file):
+            pytest.fail(
+                'No reference file at %r to compare against' % (
+                    os.path.relpath(output_file, ROOT_DIR),
+                ),
+                pytrace=False,
+            )
+
         if os.path.isdir(output_file):
             if not os.path.isdir(reference_file):
                 pytest.fail(


### PR DESCRIPTION
If we use the latter, we see a really ugly, hard-to-parse traceback. The latter is much more subtle so use that.

The 'pytrace' variable is set to False on all values to avoid triggering a full traceback from 'pytest.fail' also [[1][1]].

[1]: https://docs.pytest.org/en/stable/reference.html#pytest-fail