### PR TITLE
Remove Python 2-only code

### DIFF
--- a/doc/assets/flowables.py
+++ b/doc/assets/flowables.py
@@ -26,10 +26,6 @@ from log import log
 import re
 from xml.sax.saxutils import unescape, escape
 
-import six
- 
-if six.PY3:
-    unicode = str
 
 class XXPreformatted(XPreformatted):
     """An extended XPreformattedFit"""
@@ -257,7 +253,7 @@ class DelayedTable(Table):
             hex(id(self)), self._frameName(),
             getattr(self, 'name', '')
                 and (' name="%s"' % getattr(self, 'name', '')) or '',
-                unicode(self.data[0])[:180])
+                str(self.data[0])[:180])
 
 def tablepadding(padding):
     if not isinstance(padding,(list,tuple)):
@@ -284,7 +280,7 @@ class SplitTable(DelayedTable):
             hex(id(self)), self._frameName(),
             getattr(self, 'name', '')
                 and (' name="%s"' % getattr(self, 'name', '')) or '',
-                unicode(self.data[0][1])[:180])
+                str(self.data[0][1])[:180])
 
     def split(self,w,h):
         _w,_h=self.wrap(w, h)
@@ -740,7 +736,7 @@ class BoundByWidth(Flowable):
             hex(id(self)), self._frameName(),
             getattr(self, 'name', '')
                 and (' name="%s"' % getattr(self, 'name', '')) or '',
-                unicode([c.identity() for c in self.content])[:80])
+                str([c.identity() for c in self.content])[:80])
 
     def wrap(self, availWidth, availHeight):
         """If we need more width than we have, complain, keep a scale"""
@@ -832,7 +828,7 @@ class BoxedContainer(BoundByWidth):
         self.mode = mode
 
     def identity(self, maxLen=None):
-        return unicode([u"BoxedContainer containing: ",
+        return str([u"BoxedContainer containing: ",
             [c.identity() for c in self.content]])[:80]
 
     def draw(self):
@@ -1022,8 +1018,8 @@ class MyTableOfContents(TableOfContents):
             if label:
                 pre = u'<a href="%s" color="%s">' % (label, self.linkColor)
                 post = u'</a>'
-                if not isinstance(text, unicode):
-                    text = unicode(text, 'utf-8')
+                if not isinstance(text, str):
+                    text = str(text, 'utf-8')
                 text = pre + text + post
             else:
                 pre = ''

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ pdfrw
 pygments
 pyPdf2
 reportlab
-six
 smartypants
 sphinx
 svglib

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ python-dateutil==2.8.1    # via matplotlib
 pytz==2019.3              # via babel
 reportlab==3.5.34
 requests==2.22.0          # via sphinx
-six==1.14.0
 smartypants==2.0.1
 snowballstemmer==2.0.0    # via sphinx
 sphinx==1.8.5

--- a/rst2pdf/basenodehandler.py
+++ b/rst2pdf/basenodehandler.py
@@ -36,7 +36,6 @@ will be logged.
 import inspect
 import types
 
-from six import with_metaclass
 from smartypants import smartypants
 import docutils.nodes
 
@@ -103,7 +102,7 @@ class MetaHelper(type):
             cls._classinit()
 
 
-class NodeHandler(with_metaclass(MetaHelper, object)):
+class NodeHandler(metaclass=MetaHelper):
     ''' NodeHandler classes are used to dispatch
        to the correct class to handle some node class
        type, via a dispatchdict in the main class.

--- a/rst2pdf/config.py
+++ b/rst2pdf/config.py
@@ -2,14 +2,8 @@
 # See LICENSE.txt for licensing terms
 """Singleton config object"""
 
+import configparser
 import os
-import six
-
-if six.PY2:
-    import ConfigParser
-else:
-    import configparser as ConfigParser
-
 
 from rst2pdf.rson import loads
 
@@ -34,7 +28,7 @@ class ConfigError(Exception):
         self.msg = msg
 
 
-conf = ConfigParser.SafeConfigParser()
+conf = configparser.SafeConfigParser()
 
 
 def parseConfig(extracf=None):
@@ -42,7 +36,7 @@ def parseConfig(extracf=None):
     cflist = ["/etc/rst2pdf.conf", cfname]
     if extracf:
         cflist.append(extracf)
-    conf = ConfigParser.SafeConfigParser()
+    conf = configparser.SafeConfigParser()
     conf.read(cflist)
 
 

--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -36,7 +36,6 @@
 
 __docformat__ = 'reStructuredText'
 from importlib import import_module
-import six
 
 import sys
 import os
@@ -45,12 +44,8 @@ import re
 import string
 import logging
 
-if six.PY2:
-    from cStringIO import StringIO
-    from urlparse import urljoin, urlparse, urlunparse
-else:
-    from io import StringIO
-    from urllib.parse import urljoin, urlparse, urlunparse
+from io import StringIO
+from urllib.parse import urljoin, urlparse, urlunparse
 from os.path import abspath, dirname, expanduser, join
 from copy import copy, deepcopy
 from optparse import OptionParser
@@ -1352,7 +1347,7 @@ def main(_args=None):
 
     if options.version:
         from rst2pdf import version
-        six.print_(version)
+        print(version)
         sys.exit(0)
 
     if options.quiet:
@@ -1370,7 +1365,8 @@ def main(_args=None):
             PATH = abspath(dirname(sys.executable))
         else:
             PATH = abspath(dirname(__file__))
-        six.print_(open(join(PATH, 'styles', 'styles.style')).read())
+        with open(join(PATH, 'styles', 'styles.style')) as fh:
+            print(fh.read())
         sys.exit(0)
 
     filename = False
@@ -1519,9 +1515,6 @@ def patch_PDFDate():
         __PDFObject__ = True
         # gmt offset now suppported
         def __init__(self, invariant=True, ts=None, dateFormatter=None):
-            #if six.PY2:
-            #    now = (2000,01,01,00,00,00,0)
-            #else:
             now = (2000,0o1,0o1,00,00,00,0)
             self.date = now[:6]
             self.dateFormatter = dateFormatter

--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -97,8 +97,6 @@ from rst2pdf.opt_imports import Paragraph, BaseHyphenator, PyHyphenHyphenator, \
 # Template engine for covers
 import jinja2
 
-if six.PY3:
-    unicode = str
 
 numberingstyles={ 'arabic': 'ARABIC',
                   'roman': 'ROMAN_UPPER',
@@ -615,8 +613,7 @@ class RstToPdf(object):
         FP = FancyPage("fancypage", head, foot, self)
 
         def cleantags(s):
-            re.sub(r'<[^>]*?>', '',
-                unicode(s).strip())
+            re.sub(r'<[^>]*?>', '', str(s).strip())
 
         pdfdoc = FancyDocTemplate(
             output,

--- a/rst2pdf/dumpstyle.py
+++ b/rst2pdf/dumpstyle.py
@@ -6,7 +6,6 @@
     to .style in the styles directory.
 '''
 
-from __future__ import absolute_import
 import sys
 import os
 

--- a/rst2pdf/dumpstyle.py
+++ b/rst2pdf/dumpstyle.py
@@ -13,10 +13,6 @@ import os
 from .rson import loads as rloads
 from json import loads as jloads
 
-try:
-    basestring # py27
-except:
-    basestring = str # Py3+
 
 def dumps(obj, forcestyledict=True):
     ''' If forcestyledict is True, will attempt to
@@ -98,8 +94,14 @@ def dumps(obj, forcestyledict=True):
     def donone(result, obj, indent):
         result.append('null')
 
-    dumpfuncs = {float: dofloat, int: doint, basestring: dostr,
-                     list: dolist, dict: dodict, type(None): donone}
+    dumpfuncs = {
+        float: dofloat,
+        int: doint,
+        str: dostr,
+        list: dolist,
+        dict: dodict,
+        type(None): donone,
+    }
 
     dumpfuncs = dumpfuncs.items()
 

--- a/rst2pdf/extensions/dotted_toc.py
+++ b/rst2pdf/extensions/dotted_toc.py
@@ -41,10 +41,6 @@ import rst2pdf.genelements as genelements
 from reportlab.platypus import Spacer
 from reportlab.platypus.tableofcontents import drawPageNumbers
 
-import six
- 
-if six.PY3:
-    unicode = str
 
 Table = genelements.Table
 Paragraph = genelements.Paragraph
@@ -138,8 +134,8 @@ class DottedTableOfContents(genelements.MyTableOfContents):
             style.textColor = self.linkColor
             key = self.refid_lut.get((level, text, pageNum), None)
             if key:
-                if not isinstance(text, unicode):
-                    text = unicode(text, 'utf-8')
+                if not isinstance(text, str):
+                    text = str(text, 'utf-8')
                 text = u'<a href="#%s">%s</a>' % (key, text)
 
             para = Paragraph('%s<onDraw name="%s" label="%s"/>' % (text, funcname, len(end_info)), style)

--- a/rst2pdf/findfonts.py
+++ b/rst2pdf/findfonts.py
@@ -14,7 +14,6 @@ import subprocess
 import sys
 from fnmatch import fnmatch
 
-import six
 from reportlab.lib.fonts import addMapping
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import (
@@ -177,8 +176,6 @@ def findFont(fname):
 def findTTFont(fname):
     def get_family(query):
         data = make_string(subprocess.check_output(["fc-match", query]))
-        if six.PY2:
-            data = data.decode("UTF-8")
         for line in data.splitlines():
             line = line.strip()
             if not line:
@@ -223,10 +220,7 @@ def findTTFont(fname):
         # ctypes with EnumFontFamiliesEx
 
         def get_nt_fname(ftname):
-            if six.PY3:
-                import winreg as _w
-            else:
-                import _winreg as _w            
+            import winreg as _w
 
             fontkey = _w.OpenKey(
                 _w.HKEY_LOCAL_MACHINE,

--- a/rst2pdf/findfonts.py
+++ b/rst2pdf/findfonts.py
@@ -7,8 +7,6 @@ Scan a list of folders and find all .afm files,
 then create rst2pdf-ready font-aliases.
 """
 
-from __future__ import unicode_literals
-
 import os
 import subprocess
 import sys

--- a/rst2pdf/genpdftext.py
+++ b/rst2pdf/genpdftext.py
@@ -10,12 +10,7 @@ import os
 import docutils.nodes
 from xml.sax.saxutils import escape
 
-import six
-
-if six.PY3:
-    from urllib.parse import urljoin, urlparse
-else:
-    from urlparse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse
 
 from reportlab.lib.units import cm
 from .opt_imports import Paragraph

--- a/rst2pdf/image.py
+++ b/rst2pdf/image.py
@@ -9,12 +9,7 @@ from copy import copy
 from reportlab.platypus.flowables import Image, Flowable
 from reportlab.lib.units import *
 
-import six
-
-if six.PY3:
-    from urllib.request import urlretrieve
-else:
-    from urllib import urlretrieve
+from urllib.request import urlretrieve
 
 from .opt_imports import PILImage, pdfinfo
 from .log import log, nodeid

--- a/rst2pdf/math_flowable.py
+++ b/rst2pdf/math_flowable.py
@@ -5,8 +5,6 @@ import tempfile
 import os
 import re
 
-import six
-
 from reportlab.platypus import *
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfbase import pdfmetrics
@@ -84,10 +82,7 @@ class Math(Flowable):
                     col_conv=ColorConverter()
                     rgb_color=col_conv.to_rgb(self.color)
                     canv.setFillColorRGB(rgb_color[0],rgb_color[1],rgb_color[2])
-                    if six.PY2:
-                        canv.drawString(ox, oy, unichr(num))
-                    else:
-                        canv.drawString(ox, oy, chr(num))
+                    canv.drawString(ox, oy, chr(num))
 
                 canv.setLineWidth(0)
                 canv.setDash([])
@@ -152,22 +147,15 @@ class Math(Flowable):
             draw = ImageDraw.Draw(img)
             for ox, oy, fontname, fontsize, num, symbol_name in glyphs:
                 font = ImageFont.truetype(fontname, int(fontsize*scale))
-                if six.PY2:
-                    tw, th = draw.textsize(unichr(num), font=font)
-                else:
-                    tw, th = draw.textsize(chr(num), font=font)
+                tw, th = draw.textsize(chr(num), font=font)
                 # No, I don't understand why that 4 is there.
                 # As we used to say in the pure math
                 # department, that was a numerical solution.
                 col_conv=ColorConverter()
                 fc=col_conv.to_rgb(self.color)
                 rgb_color=(int(fc[0]*255),int(fc[1]*255),int(fc[2]*255))
-                if six.PY2:
-                    draw.text((ox*scale, (height - oy - fontsize + 4)*scale),
-                            unichr(num), font=font,fill=rgb_color)
-                else:
-                    draw.text((ox*scale, (height - oy - fontsize + 4)*scale),
-                            chr(num), font=font,fill=rgb_color)
+                draw.text((ox*scale, (height - oy - fontsize + 4)*scale),
+                        chr(num), font=font,fill=rgb_color)
             for ox, oy, w, h in rects:
                 x1 = ox*scale
                 x2 = x1 + w*scale

--- a/rst2pdf/opt_imports.py
+++ b/rst2pdf/opt_imports.py
@@ -10,8 +10,6 @@ opt_imports.py contains logic for handling optional imports.
 import os
 import sys
 
-import six
-
 from .log import log
 
 PyHyphenHyphenator = None

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -843,10 +843,6 @@ def try_parse(src):
     # lines beginning with "..." are probably placeholders for suite
     src = re.sub(r"(?m)^(\s*)" + mark + "(.)", r"\1"+ mark + r"# \2", src)
 
-    # if we're using 2.5, use the with statement
-    if sys.version_info >= (2, 5):
-        src = 'from __future__ import with_statement\n' + src
-
     if not isinstance(src, bytes):
         # Non-ASCII chars will only occur in string literals
         # and comments.  If we wanted to give them to the parser

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -145,8 +145,8 @@ class PDFBuilder(Builder):
                 self.spinx_logger.info("writing " + targetname + "... ")
                 docwriter.write(doctree, destination)
                 self.spinx_logger.info("done")
-            except Exception as e:
-                log.exception(e)
+            except Exception:
+                log.exception('Failed to build doc')
                 self.spinx_logger.info(red("FAILED"))
 
     def init_document_data(self):
@@ -298,7 +298,7 @@ class PDFBuilder(Builder):
 
         if appendices:
             tree.append(nodes.raw(text='OddPageBreak %s'%self.page_template, format='pdf'))
-            self.spinx_logger.info()
+            self.spinx_logger.info('')
             self.spinx_logger.info('adding appendixes...')
             for docname in appendices:
                 self.spinx_logger.info(darkgreen(docname) + " ")

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -13,16 +13,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-import six
 import logging
-if six.PY2:
-    try:
-        import parser
-    except ImportError:
-        # parser is not available on Jython
-        parser = None
-else:
-    parser = None
 import re
 import sys
 import os
@@ -35,10 +26,7 @@ from xml.sax.saxutils import unescape, escape
 from traceback import print_exc
 
 from io import BytesIO
-if six.PY2:
-    from urlparse import urljoin, urlparse, urlunparse
-else:
-    from urllib.parse import urljoin, urlparse, urlunparse
+from urllib.parse import urljoin, urlparse, urlunparse
 
 from pygments.lexers import get_lexer_by_name, guess_lexer
 
@@ -867,14 +855,7 @@ def try_parse(src):
         # just replace all non-ASCII characters.
         src = src.encode('ascii', 'replace')
 
-    if parser is None:
-        return True
-    try:
-        parser.suite(src)
-    except (SyntaxError, UnicodeEncodeError):
-        return False
-    else:
-        return True
+    return True
 
 
 def setup(app):

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -80,7 +80,7 @@ class PDFBuilder(Builder):
     def init(self):
         self.docnames = []
         self.document_data = []
-        self.spinx_logger = sphinx.util.logging.getLogger(__name__)
+        self.sphinx_logger = sphinx.util.logging.getLogger(__name__)
 
     def write(self, *ignored):
 
@@ -99,7 +99,7 @@ class PDFBuilder(Builder):
                     opts=entry[4]
                 else:
                     opts={}
-                self.spinx_logger.info("processing " + targetname + "... ")
+                self.sphinx_logger.info("processing " + targetname + "... ")
                 self.opts = opts
                 class dummy:
                     extensions=self.config.pdf_extensions
@@ -141,13 +141,13 @@ class PDFBuilder(Builder):
                     appendices=opts.get('pdf_appendices', self.config.pdf_appendices) or [])
                 doctree.settings.author=author
                 doctree.settings.title=title
-                self.spinx_logger.info("done")
-                self.spinx_logger.info("writing " + targetname + "... ")
+                self.sphinx_logger.info("done")
+                self.sphinx_logger.info("writing " + targetname + "... ")
                 docwriter.write(doctree, destination)
-                self.spinx_logger.info("done")
+                self.sphinx_logger.info("done")
             except Exception:
                 log.exception('Failed to build doc')
-                self.spinx_logger.info(red("FAILED"))
+                self.sphinx_logger.info(red("FAILED"))
 
     def init_document_data(self):
         preliminary_document_data = map(list, self.config.pdf_documents)
@@ -174,7 +174,7 @@ class PDFBuilder(Builder):
         # check how the LaTeX builder does it.
 
         self.docnames = set([docname])
-        self.spinx_logger.info(darkgreen(docname) + " ")
+        self.sphinx_logger.info(darkgreen(docname) + " ")
         def process_tree(docname, tree):
             tree = tree.deepcopy()
             for toctreenode in tree.traverse(addnodes.toctree):
@@ -182,7 +182,7 @@ class PDFBuilder(Builder):
                 includefiles = map(str, toctreenode['includefiles'])
                 for includefile in includefiles:
                     try:
-                        self.spinx_logger.info(darkgreen(includefile) + " ")
+                        self.sphinx_logger.info(darkgreen(includefile) + " ")
                         subtree = process_tree(includefile,
                         self.env.get_doctree(includefile))
                         self.docnames.add(includefile)
@@ -265,7 +265,7 @@ class PDFBuilder(Builder):
             )
             # In HTML this is handled with a Jinja template, domainindex.html
             # We have to generate docutils stuff right here in the same way.
-            self.spinx_logger.info(' ' + indexname)
+            self.sphinx_logger.info(' ' + indexname)
             print
 
             output=['DUMMY','=====','',
@@ -298,16 +298,16 @@ class PDFBuilder(Builder):
 
         if appendices:
             tree.append(nodes.raw(text='OddPageBreak %s'%self.page_template, format='pdf'))
-            self.spinx_logger.info('')
-            self.spinx_logger.info('adding appendixes...')
+            self.sphinx_logger.info('')
+            self.sphinx_logger.info('adding appendixes...')
             for docname in appendices:
-                self.spinx_logger.info(darkgreen(docname) + " ")
+                self.sphinx_logger.info(darkgreen(docname) + " ")
                 appendix = self.env.get_doctree(docname)
                 appendix['docname'] = docname
                 tree.append(appendix)
-            self.spinx_logger.info('done')
+            self.sphinx_logger.info('done')
 
-        # Replace Sphinx's HighlightLanguageTransform with our own for Spinx version between 1.8.0 & less than 2.0.0 as
+        # Replace Sphinx's HighlightLanguageTransform with our own for sphinx version between 1.8.0 & less than 2.0.0 as
         # Sphinx's HighlightLanguageTransform breaks linenothreshold setting in the highlight directive (See issue #721)
         # This code can be removed when we drop support for Python 2
         if sphinx.__version__ > '1.7.9' and sphinx.__version__ < '2.0.0':
@@ -316,7 +316,7 @@ class PDFBuilder(Builder):
                     self.env.app.registry.post_transforms[i] = HighlightLanguageTransform
                     break
 
-        self.spinx_logger.info("resolving references...")
+        self.sphinx_logger.info("resolving references...")
         self.env.resolve_references(tree, docname, self)
 
         for pendingnode in tree.traverse(addnodes.pending_xref):

--- a/rst2pdf/pygments2style.py
+++ b/rst2pdf/pygments2style.py
@@ -4,7 +4,6 @@
 Creates a rst2pdf stylesheet for each pygments style.
 '''
 
-from __future__ import absolute_import
 import sys
 import os
 from . import dumpstyle

--- a/rst2pdf/pygments_code_block_directive.py
+++ b/rst2pdf/pygments_code_block_directive.py
@@ -35,11 +35,6 @@
 import codecs
 from docutils import nodes
 from docutils.parsers.rst import directives
-import six
-
-if six.PY3:
-    unicode = str
-    basestring = str
 
 try:
     import pygments
@@ -93,7 +88,7 @@ class DocutilsInterface(object):
     def lex(self):
         # Get lexer for language (use text as fallback)
         try:
-            if self.language and unicode(self.language).lower() != 'none':
+            if self.language and str(self.language).lower() != 'none':
                 lexer = get_lexer_by_name(self.language.lower(),
                                         **self.custom_args
                                         )

--- a/rst2pdf/rson.py
+++ b/rst2pdf/rson.py
@@ -140,7 +140,7 @@ class Tokenizer(list):
     splitter = re.compile(pattern).split
 
     @classmethod
-    def factory(cls, len=len, iter=iter, unicode=unicode, isinstance=isinstance):
+    def factory(cls):
         splitter = cls.splitter
         delimiterset = set(cls.delimiterset) | set('"')
 
@@ -259,6 +259,7 @@ def make_hashable(what):
             return tuple(sorted(make_hashable(x) for x in what.items()))
         return tuple(make_hashable(x) for x in what)
 
+
 class BaseObjects(object):
 
     # These hooks allow compatibility with simplejson
@@ -314,7 +315,7 @@ class BaseObjects(object):
         def get_result(self, token):
             return self
 
-    def object_type_factory(self, dict=dict, tuple=tuple):
+    def object_type_factory(self):
         ''' This function returns constructors for RSON objects and arrays.
             It handles simplejson compatible hooks as well.
         '''
@@ -329,9 +330,11 @@ class BaseObjects(object):
             self.disallow_nonstring_keys = True
         elif object_hook is not None:
             mydict = dict
+
             class build_object(list):
                 def get_result(self, token):
                     return object_hook(mydict(self))
+
             self.disallow_multiple_object_keys = True
             self.disallow_nonstring_keys = True
         else:
@@ -347,7 +350,7 @@ class Dispatcher(object):
     '''
 
     @classmethod
-    def dispatcher_factory(cls, hasattr=hasattr, tuple=tuple, sorted=sorted):
+    def dispatcher_factory(cls):
 
         self = cls()
         parser_factory = self.parser_factory
@@ -407,7 +410,7 @@ class QuotedToken(object):
                          r'\r': u'\r',
                          r'\t': u'\t'}.get
 
-    def quoted_parse_factory(self, int=int, iter=iter, len=len):
+    def quoted_parse_factory(self):
         quoted_splitter = self.quoted_splitter
         quoted_mapper = self.quoted_mapper
         parse_quoted_str = self.parse_quoted_str
@@ -529,7 +532,7 @@ class UnquotedToken(object):
             lambda token: token[2].decode('utf-8'))
     else:
         parse_unquoted_str = staticmethod(
-            lambda token, unicode=str: str(token[2]))
+            lambda token: str(token[2]))
 
     special_strings = dict(true=True, false=False, null=None)
 
@@ -677,7 +680,7 @@ class RsonParser(object):
     def client_info(self, parse_locals):
         pass
 
-    def parser_factory(self, len=len, type=type, isinstance=isinstance, list=list, basestring=basestring):
+    def parser_factory(self):
 
         Tokenizer = self.Tokenizer
         tokenizer = Tokenizer.factory()

--- a/rst2pdf/rson.py
+++ b/rst2pdf/rson.py
@@ -58,10 +58,6 @@ import sys
 
 import six
 
-if six.PY3:
-    unicode = str
-    basestring = str
-
 
 class RSONDecodeError(ValueError):
     pass
@@ -748,7 +744,7 @@ class RsonParser(object):
                         error('Unexpected trailing comma', token)
                     break
                 key = json_value_dispatch(t0, bad_dict_key)(token, next)
-                if disallow_nonstring_keys and not isinstance(key, basestring):
+                if disallow_nonstring_keys and not isinstance(key, str):
                     error('Non-string key %s not supported' % repr(key), token)
                 token = next()
                 t0 = token[1]
@@ -889,7 +885,7 @@ class RsonParser(object):
                 error("rson client's object handlers do not support chained objects", token)
             if disallow_nonstring_keys:
                 for key in entry[:-1]:
-                    if not isinstance(key, basestring):
+                    if not isinstance(key, str):
                         error('Non-string key %s not supported' % repr(key), token)
             mydict.append(entry)
             return token

--- a/rst2pdf/rson.py
+++ b/rst2pdf/rson.py
@@ -21,8 +21,6 @@ Additional documentation available at:
 http://code.google.com/p/rson/
 '''
 
-from __future__ import unicode_literals
-
 __version__ = '0.08'
 
 __author__ = 'Patrick Maupin <pmaupin@gmail.com>'

--- a/rst2pdf/styles.py
+++ b/rst2pdf/styles.py
@@ -19,8 +19,6 @@ from reportlab.pdfbase import pdfmetrics
 import reportlab.lib.pagesizes as pagesizes
 import reportlab.rl_config
 
-import six
-
 from rst2pdf.rson import loads as rson_loads
 
 from . import findfonts
@@ -44,10 +42,7 @@ class StyleSheet(object):
         '''
         styles = data.get('styles', {})
         try:
-            if six.PY2:
-                stylenames = styles.keys()
-            if six.PY3:
-                stylenames = list(styles.keys())
+            stylenames = list(styles.keys())
         except AttributeError:
             for style in styles:
                 yield style
@@ -228,7 +223,7 @@ class StyleSheet(object):
             for font in embedded:
                 try:
                     # Just a font name, try to embed it
-                    if isinstance(font, six.string_types):
+                    if isinstance(font, str):
                         # See if we can find the font
                         fname, pos = findfonts.guessFont(font)
                         if font in embedded_fontnames:

--- a/rst2pdf/writer.py
+++ b/rst2pdf/writer.py
@@ -7,11 +7,6 @@ from docutils import writers
 
 from rst2pdf import createpdf
 
-import six
- 
-if six.PY3:
-    unicode = str
-    basestring = str
 
 class PdfWriter(writers.Writer):
 
@@ -31,7 +26,7 @@ class PdfWriter(writers.Writer):
         sio = StringIO('')
         createpdf.RstToPdf(sphinx=True).createPdf(
             doctree=self.document, output=sio, compressed=False)
-        self.output = unicode(sio.getvalue(), 'utf-8', 'ignore')
+        self.output = str(sio.getvalue(), 'utf-8', 'ignore')
 
     def supports(self, format):
         """This writer supports all format-specific elements."""

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'pygments',
         'reportlab',
         'setuptools',
-        'six',
         'smartypants',
     ],
     extras_require={


### PR DESCRIPTION
This depends on #841. Remove six, unnecessary future imports, and code that is only used under the now-unsupported Python 2.7 environment.