### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,14 @@
+# Commits to be ignored when running `git blame`
+#
+# Use by setting this config locally:
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# or by on the command line:
+#     git blame --ignore-revs-file .git-blame-ignore-revs <filename>
+
+
+# Run code through black
+825ba00bb95c0a9bb801ccb4c6dd74ec7b59b59e
+
+# Resolve various style issues
+a6aff6bf8da21a4e6377238ae95b3c9bb941d655

--- a/doc/DEVELOPERS.rst
+++ b/doc/DEVELOPERS.rst
@@ -93,6 +93,17 @@ It's important that you do it this way because it means that the rest of us
 know what you are doing. It also means you don't break rst2pdf.
 
 
+Git config
+~~~~~~~~~~
+
+After the mass-reformatting in PR 877, it is helpful to ignore the relevant
+commits that simply reformatted the code when using git blame.
+
+The ``..git-blame-ignore-revs`` file contains the list of commits to ignore
+and you can use this git config line to make ``git blame`` work more usefully::
+
+    git config blame.ignoreRevsFile .git-blame-ignore-revs
+
 Pre-commit
 ~~~~~~~~~~
 


### PR DESCRIPTION
After the mass-reformatting in PR #877, it is helpful to ignore the commits that simply reformat the code when using `git blame` as it makes it more useful.

This is most easily done using a file containing the list of commits - I've called it `.git-blame-ignore-revs` - and a config setting (`git config blame.ignoreRevsFile .git-blame-ignore-revs`).
