### PR TITLE
style: Fix headers of files

### DIFF
--- a/doc/assets/flowables.py
+++ b/doc/assets/flowables.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 __docformat__ = 'reStructuredText'
 

--- a/rst2pdf/__init__.py
+++ b/rst2pdf/__init__.py
@@ -1,4 +1,4 @@
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 # TODO(stephenfin): Switch to 'importlib.metadata' once we drop support for
 # Python < 3.8

--- a/rst2pdf/basenodehandler.py
+++ b/rst2pdf/basenodehandler.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
-'''
+"""
 This module provides one useful class:  NodeHandler
 
 The NodeHandler class is designed to be subclassed.  Each subclass
@@ -29,7 +28,7 @@ to handle the given docutils node instance.
 If no NodeHandler subclass has been created to handle that particular
 type of docutils node, then default processing will occur and a warning
 will be logged.
-'''
+"""
 
 import inspect
 import types

--- a/rst2pdf/config.py
+++ b/rst2pdf/config.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 """Singleton config object"""
 
@@ -7,7 +6,6 @@ import configparser
 import os
 
 from rst2pdf.rson import loads
-
 
 cfdir = os.path.join(os.path.expanduser('~'), '.rst2pdf')
 cfname = os.path.join(cfdir, 'config')

--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -1,38 +1,36 @@
-# -*- coding: utf-8 -*-
-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 # Some fragments of code are copied from Reportlab under this license:
 #
-#####################################################################################
+###############################################################################
 #
-#       Copyright (c) 2000-2008, ReportLab Inc.
-#       All rights reserved.
+# Copyright (c) 2000-2008, ReportLab Inc.
+# All rights reserved.
 #
-#       Redistribution and use in source and binary forms, with or without modification,
-#       are permitted provided that the following conditions are met:
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
 #
-#               *       Redistributions of source code must retain the above copyright notice,
-#                       this list of conditions and the following disclaimer.
-#               *       Redistributions in binary form must reproduce the above copyright notice,
-#                       this list of conditions and the following disclaimer in the documentation
-#                       and/or other materials provided with the distribution.
-#               *       Neither the name of the company nor the names of its contributors may be
-#                       used to endorse or promote products derived from this software without
-#                       specific prior written permission.
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the company nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
 #
-#       THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-#       ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-#       WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-#       IN NO EVENT SHALL THE OFFICERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-#       INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-#       TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-#       OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-#       IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-#       IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-#       SUCH DAMAGE.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE OFFICERS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-#####################################################################################
+###############################################################################
 
 __docformat__ = 'reStructuredText'
 

--- a/rst2pdf/directives/aafigure.py
+++ b/rst2pdf/directives/aafigure.py
@@ -1,29 +1,6 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: BSD
+#
 # Copyright (c) 2009 by Leandro Lucarella, Roberto Alsina
-# All rights reserved.
-
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-
-# * Redistributions of source code must retain the above copyright
-#   notice, this list of conditions and the following disclaimer.
-
-# * Redistributions in binary form must reproduce the above copyright
-#   notice, this list of conditions and the following disclaimer in the
-#   documentation and/or other materials provided with the distribution.
-
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from docutils.nodes import Element, literal_block
 from docutils.parsers.rst import directives

--- a/rst2pdf/directives/code_block.py
+++ b/rst2pdf/directives/code_block.py
@@ -1,33 +1,23 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Unlicense
 
-# :Author: a Pygments author|contributor; Felix Wiemann; Guenter Milde
-# :Date: $Date$
-# :Copyright: This module has been placed in the public domain.
-#
-# This is a merge of `Using Pygments in ReST documents`_ from the pygments_
-# documentation, and a `proof of concept`_ by Felix Wiemann.
-#
-# ========== ===========================================================
-# 2007-06-01 Removed redundancy from class values.
-# 2007-06-04 Merge of successive tokens of same type
-#            (code taken from pygments.formatters.others).
-# 2007-06-05 Separate docutils formatter script
-#            Use pygments' CSS class names (like the html formatter)
-#            allowing the use of pygments-produced style sheets.
-# 2007-06-07 Merge in the formatting of the parsed tokens
-#            (misnamed as docutils_formatter) as class DocutilsInterface
-# 2007-06-08 Failsave implementation (fallback to a standard literal block
-#            if pygments not found)
-# ========== ===========================================================
-#
-# ::
+"""Define and register a code-block directive using pygments.
 
-"""Define and register a code-block directive using pygments"""
+This is a merge of `Using Pygments in ReST documents`_ from the pygments_
+documentation, and a `proof of concept`_ by Felix Wiemann.
 
-
-# Requirements
-# ------------
-# ::
+========== ===========================================================
+2007-06-01 Removed redundancy from class values.
+2007-06-04 Merge of successive tokens of same type
+           (code taken from pygments.formatters.others).
+2007-06-05 Separate docutils formatter script
+           Use pygments' CSS class names (like the html formatter)
+           allowing the use of pygments-produced style sheets.
+2007-06-07 Merge in the formatting of the parsed tokens
+           (misnamed as docutils_formatter) as class DocutilsInterface
+2007-06-08 Failsave implementation (fallback to a standard literal block
+           if pygments not found)
+========== ===========================================================
+"""
 
 import codecs
 

--- a/rst2pdf/directives/noop.py
+++ b/rst2pdf/directives/noop.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 
 def noop_directive(

--- a/rst2pdf/directives/oddeven.py
+++ b/rst2pdf/directives/oddeven.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
 
 """A custom directive that allows alternative contents to be generated
 on odd and even pages."""

--- a/rst2pdf/dumpstyle.py
+++ b/rst2pdf/dumpstyle.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+#
+# SPDX-License-Identifier: MIT
+
 '''
     Call dumps() to dump a stylesheet to a string.
 

--- a/rst2pdf/extensions/__init__.py
+++ b/rst2pdf/extensions/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 '''
 This place-holder module makes the extensions directory
 into a Python "package", so that external user-specific

--- a/rst2pdf/extensions/dotted_toc.py
+++ b/rst2pdf/extensions/dotted_toc.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 # Some fragments of code are copied from Reportlab under this license:
 #

--- a/rst2pdf/extensions/fancytitles.py
+++ b/rst2pdf/extensions/fancytitles.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+
 import codecs
 import tempfile
 

--- a/rst2pdf/extensions/plantuml_r2p.py
+++ b/rst2pdf/extensions/plantuml_r2p.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 '''
 A rst2pdf extension to implement something similar to sphinx's plantuml extension
 (see http://pypi.python.org/pypi/sphinxcontrib-plantuml)

--- a/rst2pdf/extensions/preprocess_r2p.py
+++ b/rst2pdf/extensions/preprocess_r2p.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
-# An extension module for rst2pdf
+# SPDX-License-Identifier: MIT
 # Copyright 2010, Patrick Maupin
-# See LICENSE.txt for licensing terms
 
-'''
+'''An extension module for rst2pdf.
+
 preprocess is a rst2pdf extension module (invoked by ``-e preprocess``
 on the rst2pdf command line).
 

--- a/rst2pdf/extensions/sample.py
+++ b/rst2pdf/extensions/sample.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 print(
     '''
 This is a sample rst2pdf extension.

--- a/rst2pdf/findfonts.py
+++ b/rst2pdf/findfonts.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+#
+# SPDX-License-Identifier: MIT
 
 """
 Scan a list of folders and find all .afm files,

--- a/rst2pdf/flowables.py
+++ b/rst2pdf/flowables.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 __docformat__ = 'reStructuredText'
 

--- a/rst2pdf/genelements.py
+++ b/rst2pdf/genelements.py
@@ -1,37 +1,36 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 # Some fragments of code are copied from Reportlab under this license:
 #
-#####################################################################################
+###############################################################################
 #
-#       Copyright (c) 2000-2008, ReportLab Inc.
-#       All rights reserved.
+# Copyright (c) 2000-2008, ReportLab Inc.
+# All rights reserved.
 #
-#       Redistribution and use in source and binary forms, with or without modification,
-#       are permitted provided that the following conditions are met:
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
 #
-#               *       Redistributions of source code must retain the above copyright notice,
-#                       this list of conditions and the following disclaimer.
-#               *       Redistributions in binary form must reproduce the above copyright notice,
-#                       this list of conditions and the following disclaimer in the documentation
-#                       and/or other materials provided with the distribution.
-#               *       Neither the name of the company nor the names of its contributors may be
-#                       used to endorse or promote products derived from this software without
-#                       specific prior written permission.
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the company nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
 #
-#       THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-#       ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-#       WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-#       IN NO EVENT SHALL THE OFFICERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-#       INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-#       TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-#       OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-#       IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-#       IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-#       SUCH DAMAGE.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE OFFICERS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-#####################################################################################
+###############################################################################
 
 from copy import copy
 

--- a/rst2pdf/genpdftext.py
+++ b/rst2pdf/genpdftext.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 import os
 from urllib.parse import urljoin, urlparse

--- a/rst2pdf/image.py
+++ b/rst2pdf/image.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
 
 from copy import copy
 import glob

--- a/rst2pdf/languages.py
+++ b/rst2pdf/languages.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 from docutils.languages import get_language as get_language
 

--- a/rst2pdf/log.py
+++ b/rst2pdf/log.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 import logging
 

--- a/rst2pdf/math_flowable.py
+++ b/rst2pdf/math_flowable.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 import os
 import re

--- a/rst2pdf/nodehandlers.py
+++ b/rst2pdf/nodehandlers.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 # Import all node handler modules here.
 # The act of importing them wires them in.

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+
 """
       Sphinx rst2pdf builder extension
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/rst2pdf/pygments2style.py
+++ b/rst2pdf/pygments2style.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
-'''
+# SPDX-License-Identifier: MIT
+
+"""
 Creates a rst2pdf stylesheet for each pygments style.
-'''
+"""
 
 import os
 

--- a/rst2pdf/roles/counter.py
+++ b/rst2pdf/roles/counter.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
 
 from docutils.nodes import Text, target
 from docutils.parsers.rst import roles

--- a/rst2pdf/roles/counter_off.py
+++ b/rst2pdf/roles/counter_off.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
 
 from docutils.parsers.rst import roles
 

--- a/rst2pdf/rson.py
+++ b/rst2pdf/rson.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 RSON -- readable serial object notation
 

--- a/rst2pdf/sectnumlinks.py
+++ b/rst2pdf/sectnumlinks.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import docutils
 
 

--- a/rst2pdf/sinker.py
+++ b/rst2pdf/sinker.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
 
 from reportlab.platypus.flowables import _listWrapOn, _FUZZ, Flowable
 

--- a/rst2pdf/sphinxnodes.py
+++ b/rst2pdf/sphinxnodes.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
-'''
+"""
 This module contains sphinx-specific node handlers.  An import
 of this module will apparently fail if sphinx.roles hasn't been
 imported.
@@ -11,7 +10,7 @@ which is kept separate from the regular one.
 
 When the SphinxHandler class is instantiated, the two dictionaries
 are combined into the instantiated object.
-'''
+"""
 
 from copy import copy
 

--- a/rst2pdf/styles.py
+++ b/rst2pdf/styles.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 from copy import copy
 import os

--- a/rst2pdf/svgimage.py
+++ b/rst2pdf/svgimage.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 from reportlab.lib.enums import TA_CENTER, TA_LEFT, TA_RIGHT
 from reportlab.platypus import Flowable, Paragraph

--- a/rst2pdf/tests/conftest.py
+++ b/rst2pdf/tests/conftest.py
@@ -1,9 +1,8 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2020, Stephen Finucane <stephen@that.guru>
+
 """
-Copyright (c) 2020, Stephen Finucane <stephen@that.guru>
-
 Automated testing for rst2pdf.
-
-See LICENSE.txt for licensing terms
 """
 
 import glob

--- a/rst2pdf/tests/profilerun.py
+++ b/rst2pdf/tests/profilerun.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: MIT
 
 """Run all tests under a profiling environment."""
 

--- a/rst2pdf/utils.py
+++ b/rst2pdf/utils.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 import shlex
 

--- a/rst2pdf/writer.py
+++ b/rst2pdf/writer.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# See LICENSE.txt for licensing terms
+# SPDX-License-Identifier: MIT
 
 from StringIO import StringIO
 


### PR DESCRIPTION
- Add [SPDX license headers](https://spdx.org/sites/cpstandard/files/pages/files/using_spdx_license_list_short_identifiers.pdf)
- Remove 'coding' header as it's not necessary in Python 3-only code