### PR TITLE
Escape the regex to remove a FutureWarning. Fixes #880

### DIFF
--- a/rst2pdf/rson.py
+++ b/rst2pdf/rson.py
@@ -88,7 +88,7 @@ class Tokenizer(list):
     # RSON syntax delimiters are tokenized separately from everything else.
     delimiterset = set(' { } [ ] : = , '.split())
 
-    re_delimiterset = ''.join(delimiterset).replace(']', r'\]')
+    re_delimiterset = ''.join(delimiterset).replace(']', r'\]').replace('[', r'\[')
 
     # Create a RE pattern for the delimiters
     delimiter_pattern = '[%s]' % re_delimiterset


### PR DESCRIPTION
Thanks to a really excellent bug report (thanks @rswarbrick), I was able to look at the regex that triggers a FutureWarning in `rson.py` (line 119, I'm so tired of this warning!) and add a little extra escaping. I can't replicate the same warning message with this change.