### PR TITLE
Restore today setting to Sphinx cover page tests

### DIFF
--- a/rst2pdf/tests/input/sphinx-issue183/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue183/conf.py
@@ -49,3 +49,6 @@ pdf_break_level = 2
 pdf_verbosity = 0
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue229/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue229/conf.py
@@ -44,3 +44,6 @@ pdf_use_coverpage = True
 
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue254/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue254/conf.py
@@ -42,3 +42,6 @@ pdf_verbosity = 0
 
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue257/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue257/conf.py
@@ -42,3 +42,6 @@ pdf_verbosity = 0
 
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue285/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue285/conf.py
@@ -33,3 +33,6 @@ pdf_break_level = 3
 pdf_verbosity = 0
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue318/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue318/conf.py
@@ -33,3 +33,6 @@ pdf_use_index = True
 pdf_domain_indices = True
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue319/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue319/conf.py
@@ -27,3 +27,6 @@ release = '0.0.0'
 
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue320/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue320/conf.py
@@ -28,3 +28,6 @@ release = '0.0.0'
 pdf_toc_depth = 2
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue360/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue360/conf.py
@@ -34,3 +34,6 @@ pdf_font_path = ['../..']
 
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue364/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue364/conf.py
@@ -53,3 +53,6 @@ pdf_use_modindex = False
 pdf_use_coverpage = False
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'

--- a/rst2pdf/tests/input/sphinx-issue367/conf.py
+++ b/rst2pdf/tests/input/sphinx-issue367/conf.py
@@ -58,3 +58,6 @@ pdf_page_template = 'customPage'
 
 pdf_invariant = True
 pdf_real_footnotes = True
+
+# Set a consistent date for the cover page
+today = 'April 29, 2018'


### PR DESCRIPTION
The cover page on a Sphinx test have a date on it that defaults to today's date. However, for the tests to pass we need the date to match the date on the reference PDF. This is controlled by the Sphinx setting `today` which we need to set.

This setting was inadvertently removed for this set of tests in PR #855 (commit 89c630b356d5bc40524c30b171629e6fe86e0885).