### PR TITLE
Document fontSize usage with percentage values

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -454,6 +454,20 @@ and not on inline styles::
     "allowWidows": 5,
     "allowOrphans": 4
 
+The ``fontSize`` attribute can receive either a number for the size of the font
+or a percentage value, which is relative to the style's parent.
+For example, the following makes the ``title`` style use 64 as its
+``fontSize``::
+
+    ["heading", {
+      "fontSize": 32
+      }],
+
+    ["title", {
+      "parent": "heading",
+      "fontSize": "200%"
+      }]
+
 The following are the only attributes that work on styles when used for
 interpreted roles (inline styles):
 


### PR DESCRIPTION
The fontSize attribute also permits percentage values which are relative
to the style's parent, but this behavior wasn't yet documented.

Add paragraph and example describing its usage in the "Style definition"
section of the manual.