### PR TITLE
docs: Drop revision, version information from meta

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3,9 +3,7 @@ How to use rst2pdf
 ==================
 
 .. meta::
-  :authors: rst2pdf project <https://rst2pdf.org>; Roberto Alsina <ralsina@netmanagers.com.ar>  and the contributors to the rst2pdf project;
-  :version: :package-version:`rst2pdf`
-  :revision: :package-revision:`rst2pdf`
+  :authors: rst2pdf project <https://rst2pdf.org>; Roberto Alsina <ralsina@netmanagers.com.ar> and the contributors to the rst2pdf project.
 
 .. header::
 


### PR DESCRIPTION
The 'meta' directive is a HTML-builder specific directive used for
generating '<meta>' tags in the output [1]. It is also supported by
Sphinx [2].

In #891, we added support for two new roles, 'package-version' and
'package-revision', that would allow us to programmatically include the
version and revision for a package in documentation. These could be used
to programmatically set the values for '<meta name="version">' and
'<meta name="revision">' tag...or so we thought. Unfortunately the
directive must contain a *flat* field list [1], meaning it's not
possible to include roles inside a field list and the roles are simply
rendered literally.

There are couple of solutions: we could go back to setting the package
version manually in the documentation, we could generate a separate file
as part of our build process and include that in the manual, or we could
simply remove these tags from the docs in favour of explicit inline
docs. We choose the final option since meta tags aren't user-visible (at
least not without inspecting the HTML) and therefore aren't massively
important.

[1] https://docutils.sourceforge.io/docs/ref/rst/directives.html#meta
[2] https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#html-metadata

Closes: #912