### PR TITLE
[BROKEN] Prepare a snap of the 0.98 release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: rst2pdf
 base: core18
-version: '0.97'
+version: '0.98'
 summary: Use a text editor. Make a PDF.
 description: |
   Create PDF reports, slide decks and other documents from the command line using **rst2pdf**.
@@ -16,6 +16,9 @@ parts:
   rst2pdf:
     plugin: python
     source: .
+    build-packages:
+      - git
+      - fontconfig
 
 apps:
   rst2pdf:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,7 @@ parts:
     source: .
     build-packages:
       - git
+    stage-packages:
       - fontconfig
 
 apps:


### PR DESCRIPTION
We tagged a 0.98 release and normally I release a snap of each release (Fixes #907 or rather it would do if it worked). However this time I have run into problems. It builds fine with the changes in this branch. It also runs if no styles are used.

However with a stylesheet, I get an error about fc-match:

```
FileNotFoundError: [Errno 2] No such file or directory: 'fc-match': 'fc-match'
```

I think this is because of the issue [here on the snapcraft forums](https://forum.snapcraft.io/t/snapped-app-not-loading-fonts-on-fedora-and-arch/12484/71) ( warning that's quite a long discussion ) detailing a mismatch between font config versions. So far, it doesn't look like there's a fix, but I'm still asking around. So don't merge the PR but I wanted to share both my work-in-progress branch and the discussion around it.