### PR TITLE
Fix requirements installation by removing wordaxe requirement

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,7 +98,7 @@ this, you can just work on your given virtualenv each time)::
     . env/bin/activate
 
     pip install pytest pytest-xdist
-    pip install -c requirements.txt .[tests,sphinx,hyphenation,svgsupport,aafiguresupport,mathsupport,rawhtmlsupport]
+    pip install -c requirements.txt .[tests,sphinx,svgsupport,aafiguresupport,mathsupport,rawhtmlsupport]
 
 Run tests
 *********

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     extras_require={
         'tests': ['pyPdf2', 'pymupdf'],
         'sphinx': ['sphinx'],
-        'hyphenation': ['wordaxe>=1.0'],
         'svgsupport': ['svglib'],
         'aafiguresupport': ['aafigure>=0.4'],
         'mathsupport': ['matplotlib'],


### PR DESCRIPTION
Wordaxe support was removed in #887. Still, it was listed as a requirement for the `hyphenation` target in `setup.py`. Since the package wasn't able to be downloaded, the installation of the requirements failed.

Since wordaxe was the only package listed in the `hyphenation` target, and hyphenation is now handled by reportlab, remove the `hyphenation` target from `setup.py`, and also remove it from the command in CONTRIBUTING.