### PR TITLE
Add dependency check for tests

### DIFF
--- a/rst2pdf/tests/conftest.py
+++ b/rst2pdf/tests/conftest.py
@@ -41,7 +41,7 @@ def can_run(command_list):
     return _can_run
 
 
-check_dependency = {}
+check_dependency = {'plantuml': can_run(["plantuml", "-pipe"])}
 
 
 def _get_metadata(pdf):

--- a/rst2pdf/tests/conftest.py
+++ b/rst2pdf/tests/conftest.py
@@ -24,6 +24,26 @@ OUTPUT_DIR = os.path.join(ROOT_DIR, 'output')
 REFERENCE_DIR = os.path.join(ROOT_DIR, 'reference')
 
 
+def can_run(command_list):
+    def _can_run():
+        try:
+            p = subprocess.Popen(
+                command_list,
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            p.terminate()
+        except FileNotFoundError:
+            return False
+        return True
+
+    return _can_run
+
+
+check_dependency = {}
+
+
 def _get_metadata(pdf):
     metadata = pdf.metadata
 
@@ -174,6 +194,20 @@ class Item(pytest.Item):
                 ignore_reason = fh.read()
 
             pytest.skip(ignore_reason)
+
+        # if '.depends' file is present, check if all dependencies are
+        # satisfied, otherwise skip test
+
+        depends_file = os.path.join(INPUT_DIR, self.name + '.depends')
+        if os.path.exists(depends_file):
+            with open(depends_file) as fh:
+                for line in fh:
+                    dep = line.rstrip('\n')
+                    try:
+                        if not check_dependency[dep]():
+                            pytest.skip("Unmet dependency for test: %s" % line)
+                    except KeyError:
+                        pytest.skip("Unknown test dependency: %s" % line)
 
         # run the actual test
 

--- a/rst2pdf/tests/input/test_uml_extension.depends
+++ b/rst2pdf/tests/input/test_uml_extension.depends
@@ -1,0 +1,1 @@
+plantuml


### PR DESCRIPTION
Add support for having a `.depends` file alongside a test, with each of its lines listing a dependency. The dependency name is indexed in the `check_dependency` dictionary, returning the method that checks if that dependency is satisfied.
If any of the dependencies listed for a test isn't satisfied, the test is skipped.

This was motivated by the `test_uml_extension`, which requires `plantuml` to be installed. In case this program wasn't present, it would cause the test to fail. Besides adding support for dependencies, this adds the `plantuml` dependency for `test_uml_extension`, so that if `plantuml` is installed it passes, otherwise it is skipped. Fixes #935.

Besides, the first commit simply fixes some Black coding style issues in the file, as the `pre-commit` git plugin wouldn't let me commit otherwise.