### PR TITLE
createpdf: Error out when importing extension fails

### DIFF
--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -791,16 +791,13 @@ class FancyDocTemplate(BaseDocTemplate):
                         flowables.insert(i, f)  # put split flowables back on the list
                 else:
                     if hasattr(f, '_postponed') and f._postponed > 4:
-                        ident = (
-                            "Flowable %s%s too large on page %d in frame %r%s of template %r"
-                            % (
-                                self._fIdent(f, 60, frame),
-                                doctemplate._fSizeString(f),
-                                self.page,
-                                self.frame.id,
-                                self.frame._aSpaceString(),
-                                self.pageTemplate.id,
-                            )
+                        ident = "Flowable %s%s too large on page %d in frame %r%s of template %r" % (
+                            self._fIdent(f, 60, frame),
+                            doctemplate._fSizeString(f),
+                            self.page,
+                            self.frame.id,
+                            self.frame._aSpaceString(),
+                            self.pageTemplate.id,
                         )
                         # leave to keep apart from the raise
                         raise LayoutError(ident)
@@ -1020,7 +1017,12 @@ class FancyPage(PageTemplate):
                 log.error("Missing %s image file: %s", which, uri)
                 return
             try:
-                w, h, _ = MyImage.size_for_node(dict(uri=uri,), self.client,)
+                w, h, _ = MyImage.size_for_node(
+                    dict(
+                        uri=uri,
+                    ),
+                    self.client,
+                )
             except ValueError:
                 # Broken image, return arbitrary stuff
                 uri = missing


### PR DESCRIPTION
Commit c3a7c5c21 modified how we imported extension modules to add
Python 3 compatibility. Unfortunately this introduced a bug, whereby we
will no longer error out if neither of our two attempts to import the
module, by full path and by module path, succeeds.

Restore this behavior.

Closes: #920