### PR TITLE
Add Python 3.9 to the build matrix and allowing it to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,14 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
+        experimental: [false]
+        include:
+          - python-version: 3.9
+            experimental: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo apt-get -y install plantuml
+        sudo apt-get -y install plantuml libxml2-dev libxslt-dev python3-dev
         python -m pip install --upgrade pip
         pip install pytest
         pip install --upgrade setuptools


### PR DESCRIPTION
This pull request updates the GitHub Actions configuration to add Python 3.9 to the build matrix but allows this new version to fail (which it does, currently). Recommend also updating reportlab for 3.9 compatibility.