### PR TITLE
Store test outputs to aid debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,12 @@ jobs:
         pre-commit run --all-files --show-diff-on-failure
       if: matrix.python-version == '3.8'
     - name: Test with pytest
+      continue-on-error: true
       run: |
         pytest -v
+    - name: Archive test output
+      uses: actions/upload-artifact@v2
+      with:
+        name: failed-tests
+        path: rst2pdf/tests/output
+        retention-days: 8


### PR DESCRIPTION
Add an artifact-storing job to the github workflows to store all test outputs. This makes the files available as an "artifact" so we can download them and debug what happened (logs and PDFs). Retains for 8 days.