### PR TITLE
Fix text formatting

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,7 +20,7 @@ Issues are always welcome here! Please give as much detail as you can; small rep
 Documentation Changes
 =====================
 
-Documentation fixes are _at least_ as valuable as code ones. The manual is in the file `doc/manual.rst` and gets converted to both PDF and HTML for https://rst2pdf.org. Please go ahead and open a pull request for each of the changes you think we need.
+Documentation fixes are *at least* as valuable as code ones. The manual is in the file `doc/manual.rst` and gets converted to both PDF and HTML for https://rst2pdf.org. Please go ahead and open a pull request for each of the changes you think we need.
 
 Open a Pull Request
 ===================


### PR DESCRIPTION
The current markdown text formatting causes the text to show incorrectly
when viewed on GitHub and causes an `Unknown target name` error if you
tried to run rst2pdf on it.

This change fixes the text to use the rst emphasis formatting and fixes
the rendering and compiling issue.