### PR TITLE
Fix crash when generating footnotes out of order under sphinx

### DIFF
--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -784,14 +784,25 @@ class PDFTranslator(nodes.SparseNodeVisitor):
         node['ids'] = ['%s_%s' % (self.footnotestack[-1], x) for x in node['ids']]
         node.children[0][0] = nodes.Text(str(self.footnotecounter))
         for id in node['backrefs']:
-            fnr = self.footnotedict[id]
-            fnr.children[0] = nodes.Text(str(self.footnotecounter))
+            try:
+                fnr = self.footnotedict[id]
+            except KeyError:
+                pass
+            else:
+                fnr.children[0] = nodes.Text(str(self.footnotecounter))
+        self.footnotedict[node['ids'][0]] = node
         self.footnotecounter += 1
 
     def visit_footnote_reference(self, node):
         node['ids'] = ['%s_%s' % (self.footnotestack[-1], x) for x in node['ids']]
         node['refid'] = '%s_%s' % (self.footnotestack[-1], node['refid'])
         self.footnotedict[node['ids'][0]] = node
+        try:
+            footnote = self.footnotedict[node['refid']]
+        except KeyError:
+            pass
+        else:
+            node.children[0] = nodes.Text(footnote.children[0][0])
 
     def visit_desc_annotation(self, node):
         pass

--- a/rst2pdf/tests/input/sphinx-footnotes-order/conf.py
+++ b/rst2pdf/tests/input/sphinx-footnotes-order/conf.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# -- General configuration -----------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = ['rst2pdf.pdfbuilder']
+
+# The master toctree document.
+master_doc = 'index'
+
+# General information about the project.
+project = u'issue158'
+copyright = u'2009, RA'
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = 'test'
+# The full version, including alpha/beta/rc tags.
+release = 'test'
+
+
+# -- Options for PDF output ----------------------------------------------------
+
+# Grouping the document tree into PDF files. List of tuples
+# (source start file, target name, title, author).
+pdf_documents = [('index', u'MyProject', u'My Project', u'Author Name')]
+
+# A comma-separated list of custom stylesheets. Example:
+pdf_stylesheets = ['sphinx']
+
+# Language to be used for hyphenation support
+pdf_language = "en_US"
+
+# If false, no index is generated.
+pdf_use_index = False
+
+# If false, no modindex is generated.
+pdf_use_modindex = False
+
+# If false, no coverpage is generated.
+pdf_use_coverpage = False
+
+pdf_verbosity = 0
+pdf_invariant = True
+pdf_real_footnotes = True

--- a/rst2pdf/tests/input/sphinx-footnotes-order/index.rst
+++ b/rst2pdf/tests/input/sphinx-footnotes-order/index.rst
@@ -1,0 +1,5 @@
+Reference [1]_ before definition.
+
+.. [1] A footnote
+
+Reference [1]_ after definition.


### PR DESCRIPTION
When using rst2pdf with sphinx, if the document has footnotes and the
footnote definition appears before any of the footnote references, it
crashes with the following error:

```
[ERROR] pdfbuilder.py:159 Failed to build doc
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/rst2pdf/pdfbuilder.py", line 156, in write
    docwriter.write(doctree, destination)
  File "/usr/lib/python3.9/site-packages/docutils/writers/__init__.py", line 78, in write
    self.translate()
  File "/usr/lib/python3.9/site-packages/rst2pdf/pdfbuilder.py", line 587, in translate
    self.document.walkabout(visitor)
  File "/usr/lib/python3.9/site-packages/docutils/nodes.py", line 214, in walkabout
    if child.walkabout(visitor):
  File "/usr/lib/python3.9/site-packages/docutils/nodes.py", line 214, in walkabout
    if child.walkabout(visitor):
  File "/usr/lib/python3.9/site-packages/docutils/nodes.py", line 214, in walkabout
    if child.walkabout(visitor):
  [Previous line repeated 2 more times]
  File "/usr/lib/python3.9/site-packages/docutils/nodes.py", line 206, in walkabout
    visitor.dispatch_visit(self)
  File "/usr/lib/python3.9/site-packages/docutils/nodes.py", line 1995, in dispatch_visit
    return method(node)
  File "/usr/lib/python3.9/site-packages/rst2pdf/pdfbuilder.py", line 787, in visit_footnote
    fnr = self.footnotedict[id]
KeyError: 'usage-model_id3'
```

This occurs because the footnote tries to set the text for all
references, even the ones that didn't appear yet. Fix this by splitting
the work, so that the footnote sets the text for the references before
it, and let the later references set their text by themselves.

I still haven't run the tests on this, because I'm having some trouble setting it up... But I'm already posting this so it can be reviewed. I did run pre-commit on this, though.