### PR TITLE
Fix filename for .git-blame-ignore-revs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -138,7 +138,7 @@ Git config
 After the mass-reformatting in PR 877, it is helpful to ignore the relevant
 commits that simply reformatted the code when using git blame.
 
-The ``..git-blame-ignore-revs`` file contains the list of commits to ignore
-and you can use this git config line to make ``git blame`` work more usefully::
+The ``.git-blame-ignore-revs`` file contains the list of commits to ignore and
+you can use this git config line to make ``git blame`` work more usefully::
 
     git config blame.ignoreRevsFile .git-blame-ignore-revs


### PR DESCRIPTION
Fix the filename (remove the additional full stop at the beginning of
the file name) and move the following word onto the line as there's more
room now.