### PR TITLE
Add pyyaml to the requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,3 +9,4 @@ sphinx==1.8.5
 svglib
 svg2rlg
 xhtml2pdf
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ pypdf2==1.26.0            # via -r requirements.in, xhtml2pdf
 python-bidi==0.4.2        # via xhtml2pdf
 python-dateutil==2.8.1    # via matplotlib
 pytz==2020.5              # via babel
+pyyaml==5.3.1             # via -r requirements.in
 reportlab==3.5.58         # via -r requirements.in, svglib, xhtml2pdf
 requests==2.25.1          # via sphinx
 six==1.15.0               # via cycler, html5lib, python-bidi, python-dateutil, sphinx, xhtml2pdf

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'pygments',
         'reportlab',
         'smartypants',
+        'pyyaml',
     ],
     extras_require={
         'tests': ['pyPdf2', 'pymupdf'],


### PR DESCRIPTION
#956 moved stylesheets to yaml, but didn't add `pyyaml` as a requirement. Add it.

This is done on top of #969, since my environment is on python 3.9 and I need it to test the change, and also because when generating the `requirements.txt` with `pip-compile` to add `pyyaml`, it updates other packages much like in #969, so doing it on top of #969 keeps the diff small.