### PR TITLE
Fix embedded references (again)

### DIFF
--- a/rst2pdf/genpdftext.py
+++ b/rst2pdf/genpdftext.py
@@ -257,16 +257,10 @@ class HandleTarget(NodeHandler, docutils.nodes.target):
                 pre = u'<a name="%s"/>' % node['ids'][0]
                 client.targets.append(node['ids'][0])
         else:
-            for attr in ['refid', 'refuri']:
-                value = node.get(attr)
-                if value:
-                    pre = '<a name="%s"/>' % value
-                    client.targets.append(value)
-                    break
-            else:
-                raise ValueError(
-                    "Target node '%s' doesn't have neither 'refid' or 'refuri'" % node
-                )
+            name = node['names'][0]
+            if name:
+                pre = '<a name="%s"/>' % name
+                client.targets.append(name)
         return pre, ''
 
 

--- a/rst2pdf/tests/input/test_embedded_reference.rst
+++ b/rst2pdf/tests/input/test_embedded_reference.rst
@@ -1,14 +1,42 @@
 Document title
 ##############
 
+
+See `last page`_.
+
+See below_, in the `next section`_, `Suspend-to-idle Resume Code Flow`_.
+
 See `below <s2idle_resume_>`_, in the `next section <Suspend-to-idle Resume Code
 Flow_>`_.
+
+See `below <s2idle_resume_>`__, in the `next section <Suspend-to-idle Resume
+Code Flow_>`__.
+
+.. raw:: pdf
+
+   PageBreak
 
 .. _s2idle_resume:
 
 Suspend-to-idle Resume Code Flow
 ================================
 
+See io_.
+
+See `io <http://man7.org/linux/man-pages/man2/ioctl.2.html>`_.
+
+See `io <http://man7.org/linux/man-pages/man2/ioctl.2.html>`__.
+
+See `ioctl()`_.
+
 See `ioctl() <ioctl_>`_.
 
 .. _ioctl: http://man7.org/linux/man-pages/man2/ioctl.2.html
+
+.. raw:: pdf
+
+   PageBreak
+
+.. _last page:
+
+Last page text.

--- a/rst2pdf/tests/reference/test_embedded_reference.pdf
+++ b/rst2pdf/tests/reference/test_embedded_reference.pdf
@@ -17,24 +17,47 @@ endobj
 endobj
 4 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 7 0 R /XYZ 109.3829 733.0236 0 ] /Rect [ 83.26291 719.0236 109.3829 731.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 19 0 R /XYZ 62.69291 767.0236 0 ] /Rect [ 83.26291 719.0236 123.8429 731.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 5 0 obj
 <<
-/Border [ 0 0 0 ] /Contents () /Dest [ 7 0 R /XYZ 195.5429 733.0236 0 ] /Rect [ 142.1829 719.0236 195.5429 731.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 18 0 R /XYZ 62.69291 768.5236 0 ] /Rect [ 83.26291 701.0236 109.3829 713.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 6 0 obj
 <<
-/A <<
-/S /URI /Type /Action /URI (http://man7.org/linux/man-pages/man2/ioctl.2.html)
->> /Border [ 0 0 0 ] /Rect [ 83.26291 668.0236 107.7029 680.0236 ] /Subtype /Link /Type /Annot
+/Border [ 0 0 0 ] /Contents () /Dest [ 18 0 R /XYZ 62.69291 768.5236 0 ] /Rect [ 142.1829 701.0236 195.5429 713.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
 7 0 obj
 <<
-/Annots [ 4 0 R 5 0 R 6 0 R ] /Contents 13 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 12 0 R /Resources <<
+/Border [ 0 0 0 ] /Contents () /Dest [ 18 0 R /XYZ 62.69291 768.5236 0 ] /Rect [ 201.1029 701.0236 361.7129 713.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 18 0 R /XYZ 62.69291 768.5236 0 ] /Rect [ 83.26291 683.0236 109.3829 695.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+9 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 18 0 R /XYZ 62.69291 768.5236 0 ] /Rect [ 142.1829 683.0236 195.5429 695.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+10 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 18 0 R /XYZ 62.69291 768.5236 0 ] /Rect [ 83.26291 665.0236 109.3829 677.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+11 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 18 0 R /XYZ 62.69291 768.5236 0 ] /Rect [ 142.1829 665.0236 195.5429 677.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+12 0 obj
+<<
+/Annots [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R ] /Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 
   /Trans <<
@@ -42,104 +65,257 @@ endobj
 >> /Type /Page
 >>
 endobj
-8 0 obj
+13 0 obj
 <<
-/Outlines 10 0 R /PageLabels 14 0 R /PageMode /UseNone /Pages 12 0 R /Type /Catalog
+/A <<
+/S /URI /Type /Action /URI (http://man7.org/linux/man-pages/man2/ioctl.2.html)
+>> /Border [ 0 0 0 ] /Rect [ 83.26291 726.0236 91.04291 738.0236 ] /Subtype /Link /Type /Annot
 >>
 endobj
-9 0 obj
+14 0 obj
 <<
-/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+/A <<
+/S /URI /Type /Action /URI (http://man7.org/linux/man-pages/man2/ioctl.2.html)
+>> /Border [ 0 0 0 ] /Rect [ 83.26291 708.0236 91.04291 720.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+15 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (http://man7.org/linux/man-pages/man2/ioctl.2.html)
+>> /Border [ 0 0 0 ] /Rect [ 83.26291 690.0236 91.04291 702.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+16 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (http://man7.org/linux/man-pages/man2/ioctl.2.html)
+>> /Border [ 0 0 0 ] /Rect [ 83.26291 672.0236 107.7029 684.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+17 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (http://man7.org/linux/man-pages/man2/ioctl.2.html)
+>> /Border [ 0 0 0 ] /Rect [ 83.26291 654.0236 107.7029 666.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+18 0 obj
+<<
+/Annots [ 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R ] /Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+19 0 obj
+<<
+/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+20 0 obj
+<<
+/Outlines 22 0 R /PageLabels 28 0 R /PageMode /UseNone /Pages 24 0 R /Type /Catalog
+>>
+endobj
+21 0 obj
+<<
+/Author () /CreationDate (D:20210109164523+03'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20210109164523+03'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
   /Subject (\(unspecified\)) /Title (Document title) /Trapped /False
 >>
 endobj
-10 0 obj
+22 0 obj
 <<
-/Count 1 /First 11 0 R /Last 11 0 R /Type /Outlines
+/Count 1 /First 23 0 R /Last 23 0 R /Type /Outlines
 >>
 endobj
-11 0 obj
+23 0 obj
 <<
-/Dest [ 7 0 R /XYZ 62.69291 707.0236 0 ] /Parent 10 0 R /Title (Suspend-to-idle Resume Code Flow)
+/Dest [ 18 0 R /XYZ 62.69291 765.0236 0 ] /Parent 22 0 R /Title (Suspend-to-idle Resume Code Flow)
 >>
 endobj
-12 0 obj
+24 0 obj
 <<
-/Count 1 /Kids [ 7 0 R ] /Type /Pages
+/Count 3 /Kids [ 12 0 R 18 0 R 19 0 R ] /Type /Pages
 >>
 endobj
-13 0 obj
+25 0 obj
 <<
-/Length 642
+/Length 1007
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
 q
 1 0 0 1 62.69291 741.0236 cm
 q
-BT 1 0 0 1 0 4 Tm 165.4949 0 Td 24 TL /F2 20 Tf 0 0 0 rg (Document title) Tj T* -165.4949 0 Td ET
+0 0 0 rg
+BT 1 0 0 1 0 4 Tm /F2 20 Tf 24 TL 165.4949 0 Td (Document title) Tj T* -165.4949 0 Td ET
 Q
 Q
 q
 1 0 0 1 62.69291 719.0236 cm
 q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (See ) Tj 0 0 .501961 rg (last page) Tj 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 701.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (See ) Tj 0 0 .501961 rg (below) Tj 0 0 0 rg (, in the ) Tj 0 0 .501961 rg (next section) Tj 0 0 0 rg (, ) Tj 0 0 .501961 rg (Suspend-to-idle Resume Code Flow) Tj 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 683.0236 cm
+q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (See ) Tj 0 0 .501961 rg (below) Tj 0 0 0 rg (, in the ) Tj 0 0 .501961 rg (next section) Tj 0 0 0 rg (.) Tj T* ET
 Q
 Q
 q
-1 0 0 1 62.69291 686.0236 cm
+1 0 0 1 62.69291 665.0236 cm
 q
-0 0 0 rg
-BT 1 0 0 1 0 3.5 Tm /F2 17.5 Tf 21 TL (Suspend-to-idle Resume Code Flow) Tj T* ET
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (See ) Tj 0 0 .501961 rg (below) Tj 0 0 0 rg (, in the ) Tj 0 0 .501961 rg (next section) Tj 0 0 0 rg (.) Tj T* ET
 Q
 Q
 q
-1 0 0 1 62.69291 668.0236 cm
+1 0 0 1 62.69291 665.0236 cm
+Q
+ 
+endstream
+endobj
+26 0 obj
+<<
+/Length 892
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (Suspend-to-idle Resume Code Flow) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 726.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (See ) Tj 0 0 .501961 rg (io) Tj 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 708.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (See ) Tj 0 0 .501961 rg (io) Tj 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 690.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (See ) Tj 0 0 .501961 rg (io) Tj 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 672.0236 cm
 q
 BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (See ) Tj 0 0 .501961 rg (ioctl\(\)) Tj 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 654.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (See ) Tj 0 0 .501961 rg (ioctl\(\)) Tj 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 654.0236 cm
+Q
+ 
+endstream
+endobj
+27 0 obj
+<<
+/Length 149
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 753.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Last page text.) Tj T* ET
 Q
 Q
  
 endstream
 endobj
-14 0 obj
+28 0 obj
 <<
-/Nums [ 0 15 0 R ]
+/Nums [ 0 29 0 R 1 30 0 R 2 31 0 R ]
 >>
 endobj
-15 0 obj
+29 0 obj
 <<
 /S /D /St 1
 >>
 endobj
+30 0 obj
+<<
+/S /D /St 2
+>>
+endobj
+31 0 obj
+<<
+/S /D /St 3
+>>
+endobj
 xref
-0 16
+0 32
 0000000000 65535 f 
 0000000073 00000 n 
 0000000114 00000 n 
 0000000221 00000 n 
 0000000333 00000 n 
-0000000500 00000 n 
-0000000667 00000 n 
-0000000868 00000 n 
-0000001103 00000 n 
-0000001208 00000 n 
-0000001479 00000 n 
-0000001553 00000 n 
-0000001673 00000 n 
-0000001733 00000 n 
-0000002426 00000 n 
-0000002467 00000 n 
+0000000501 00000 n 
+0000000669 00000 n 
+0000000837 00000 n 
+0000001005 00000 n 
+0000001173 00000 n 
+0000001341 00000 n 
+0000001510 00000 n 
+0000001679 00000 n 
+0000001947 00000 n 
+0000002149 00000 n 
+0000002351 00000 n 
+0000002553 00000 n 
+0000002755 00000 n 
+0000002957 00000 n 
+0000003210 00000 n 
+0000003416 00000 n 
+0000003522 00000 n 
+0000003794 00000 n 
+0000003868 00000 n 
+0000003989 00000 n 
+0000004064 00000 n 
+0000005123 00000 n 
+0000006066 00000 n 
+0000006266 00000 n 
+0000006325 00000 n 
+0000006359 00000 n 
+0000006393 00000 n 
 trailer
 <<
 /ID 
-[<81f33aa2752cbadb38522c32328d07da><81f33aa2752cbadb38522c32328d07da>]
+[<5f1ba6ca00ebdf3862cfa6abefd2d1e0><5f1ba6ca00ebdf3862cfa6abefd2d1e0>]
 % ReportLab generated PDF document -- digest (http://www.reportlab.com)
 
-/Info 9 0 R
-/Root 8 0 R
-/Size 16
+/Info 21 0 R
+/Root 20 0 R
+/Size 32
 >>
 startxref
-2501
+6427
 %%EOF


### PR DESCRIPTION
#820 didn't actually fix embedded references. It made rst2pdf no longer crash, but with it, using embedded references makes the links point to the wrong place. Using the test edited in this PR as an example:

There is a target on the heading on the second page:
```
.. _s2idle_resume:
```

However, with the "fix" in #820, the following reference:
```
`below <s2idle_resume_>`_
```

that should link to the heading on the second page, produces an anchor named `s2idle_resume` (`<a name="s2idle_resume">`), effectively hiding the heading's anchor and making all other links point to ``` `below <s2idle_resume_>`_ ``` instead, which is on the first page rather than the second.

In this PR, I'm using the `name` property from the node instead of `refuri` so that no longer happens. But I honestly don't even know the purpose of this `get_pre_post()` function, as removing its whole body works just as well...

I also added all different reference types I could think of to the `embedded_reference` test, to make sure everything is working, and also page breaks, so it is actually possible to notice if it doesn't (the original test had everything in a single page, so the issue wasn't visible). Be aware, though, that the test framework doesn't mark it as a fail if the link points to the wrong place.

I'm marking this PR as WIP since, even though it works the way it is, I think we should discuss this over.