### PR TITLE
fix versionadded & version changed directives

### DIFF
--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -35,7 +35,7 @@ from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.locale import _
-from sphinx.locale import versionlabels
+from sphinx.domains.changeset import versionlabels
 from sphinx.transforms import SphinxTransform
 from sphinx.util.console import darkgreen, red
 from sphinx.util import SEP
@@ -733,13 +733,7 @@ class PDFTranslator(nodes.SparseNodeVisitor):
         raise nodes.SkipNode
 
     def visit_versionmodified(self, node):
-        text = versionlabels[node['type']] % node['version']
-        if len(node):
-            text += ': '
-        else:
-            text += '.'
         replacement = nodes.paragraph()
-        replacement += nodes.Text(text)
         replacement.extend(node.children)
         node.parent.replace(node, replacement)
 

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -35,7 +35,6 @@ from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.locale import _
-from sphinx.domains.changeset import versionlabels
 from sphinx.transforms import SphinxTransform
 from sphinx.util.console import darkgreen, red
 from sphinx.util import SEP

--- a/rst2pdf/tests/input/sphinx-versionmodified/conf.py
+++ b/rst2pdf/tests/input/sphinx-versionmodified/conf.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+# -- General configuration -----------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = ['rst2pdf.pdfbuilder']
+
+# The master toctree document.
+master_doc = 'index'
+
+# General information about the project.
+project = u'sphinxmarkup'
+copyright = u'2020'
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = 'test'
+# The full version, including alpha/beta/rc tags.
+release = 'test'
+
+
+# -- Options for PDF output ----------------------------------------------------
+
+# Grouping the document tree into PDF files. List of tuples
+# (source start file, target name, title, author).
+pdf_documents = [('index', u'sphinx-versionmodified', u'My Project', u'Author Name')]
+
+# A comma-separated list of custom stylesheets. Example:
+pdf_stylesheets = ['sphinx']
+
+# Language to be used for hyphenation support
+pdf_language = "en_US"
+
+# If false, no index is generated.
+pdf_use_index = True
+
+# If false, no modindex is generated.
+pdf_use_modindex = False
+
+# If false, no coverpage is generated.
+pdf_use_coverpage = False

--- a/rst2pdf/tests/input/sphinx-versionmodified/index.rst
+++ b/rst2pdf/tests/input/sphinx-versionmodified/index.rst
@@ -1,0 +1,15 @@
+
+.. versionadded:: 0.0.1
+
+.. versionadded:: 0.1.0
+    this feature was added
+
+.. versionchanged:: 1.0.0
+    stable release changes
+
+.. versionchanged:: 1.0.1
+
+.. deprecated:: 0.0.2
+
+.. deprecated:: 0.2.0
+    this feature has been deprecated

--- a/rst2pdf/tests/reference/sphinx-versionmodified.pdf
+++ b/rst2pdf/tests/reference/sphinx-versionmodified.pdf
@@ -32,7 +32,7 @@ endobj
 endobj
 6 0 obj
 <<
-/Author () /CreationDate (D:20210111005323+08'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20210111005323+08'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+/Author () /CreationDate (D:20210111022659+08'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20210111022659+08'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
   /Subject (\(unspecified\)) /Title () /Trapped /False
 >>
 endobj
@@ -115,7 +115,7 @@ xref
 trailer
 <<
 /ID 
-[<3509e629ce42bf9d3e19f3109adab622><3509e629ce42bf9d3e19f3109adab622>]
+[<2b541e10061e4a5dda1d312fc310c54b><2b541e10061e4a5dda1d312fc310c54b>]
 % ReportLab generated PDF document -- digest (http://www.reportlab.com)
 
 /Info 6 0 R

--- a/rst2pdf/tests/reference/sphinx-versionmodified.pdf
+++ b/rst2pdf/tests/reference/sphinx-versionmodified.pdf
@@ -1,0 +1,127 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageLabels 9 0 R /PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author () /CreationDate (D:20210111005323+08'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20210111005323+08'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title () /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Length 875
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 787.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL (New in version 0.0.1.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 769.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (New in version 0.1.0: ) Tj /F1 10 Tf (this feature was added) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 751.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (Changed in version 1.0.0: ) Tj /F1 10 Tf (stable release changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 733.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL (Changed in version 1.0.1.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 715.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL (Deprecated since version 0.0.2.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 697.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (Deprecated since version 0.2.0: ) Tj /F1 10 Tf (this feature has been deprecated) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+9 0 obj
+<<
+/Nums [ 0 10 0 R ]
+>>
+endobj
+10 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000336 00000 n 
+0000000539 00000 n 
+0000000625 00000 n 
+0000000882 00000 n 
+0000000941 00000 n 
+0000001866 00000 n 
+0000001906 00000 n 
+trailer
+<<
+/ID 
+[<3509e629ce42bf9d3e19f3109adab622><3509e629ce42bf9d3e19f3109adab622>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 11
+>>
+startxref
+1940
+%%EOF

--- a/rst2pdf/tests/reference/sphinx-versionmodified.pdf
+++ b/rst2pdf/tests/reference/sphinx-versionmodified.pdf
@@ -32,7 +32,7 @@ endobj
 endobj
 6 0 obj
 <<
-/Author () /CreationDate (D:20210111022659+08'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20210111022659+08'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+/Author () /CreationDate (D:20210111171244+08'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20210111171244+08'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
   /Subject (\(unspecified\)) /Title () /Trapped /False
 >>
 endobj
@@ -115,7 +115,7 @@ xref
 trailer
 <<
 /ID 
-[<2b541e10061e4a5dda1d312fc310c54b><2b541e10061e4a5dda1d312fc310c54b>]
+[<ddc5e43b31b6b7507864826112425cec><ddc5e43b31b6b7507864826112425cec>]
 % ReportLab generated PDF document -- digest (http://www.reportlab.com)
 
 /Info 6 0 R


### PR DESCRIPTION
closes #981 
I don't know when, but there was a change to how the `versionlabels` dict was declared (& possibly changed usage also) in Sphinx. This resulted in a failure to build a pdf when using `versionadded`, `versionchanged`, and `deprecated` directives.

See #981 for problematic output and concluding solution.

This PR fixes the pdfbuilder.py to compensate for the changes in Sphinx.