### PR TITLE
Remove wordaxe from issue template since we no longer use it

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -24,9 +24,6 @@
 <!--- (Optional) If you are using Sphinx, please paste output of this too.-->
 `pip freeze | grep Sphinx`
 
-<!--- (Optional) If you are using wordaxe, please write the version of it below:.-->
-(Optional) wordaxe version :
-
 Which operating system are you using?
 
 **Additional information**


### PR DESCRIPTION
A tiny fix to remove something from our long-winded issue template that we no longer need. Every little helps!