### PR TITLE
Update CI versions and only upload assets on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
         experimental: [false]
-        include:
-          - python-version: 3.10-dev
-            experimental: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         experimental: [false]
         include:
-          - python-version: 3.9
+          - python-version: 3.10-dev
             experimental: true
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         pytest -v
     - name: Archive test output
       uses: actions/upload-artifact@v2
+      if: failure()
       with:
         name: failed-tests
         path: rst2pdf/tests/output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install apt dependencies
       run: |
         sudo apt-get -y install plantuml libxml2-dev libxslt-dev python3-dev
+    - name: Install pip dependencies
+      run: |
         python -m pip install --upgrade pip
-        pip install pytest
         pip install --upgrade setuptools
         pip install pytest pre-commit
         pip install -c requirements.txt -e .[tests,sphinx,svgsupport,aafiguresupport,mathsupport,rawhtmlsupport]


### PR DESCRIPTION
We require the tests to pass under Python 3.9 now. Python 3.10 is in early dev, but we should test it, allowing it to fail - which it does!

Also only upload the test output files if they fail as we don't need them if the tests pass. It'd be neater to only upload the failed PDF and log files, but this is a good first step.

Finally, split the install dependencies step to separate the apt installation from the pip one as it makes it easier to diagnose when it fails due to fewer lines to scroll through.