### PR TITLE
Make sure table columns are wide enough to use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install apt dependencies
       run: |
-        sudo apt-get -y install plantuml libxml2-dev libxslt-dev python3-dev
+        sudo apt-get update && apt-get -y install plantuml libxml2-dev libxslt-dev python3-dev
     - name: Install pip dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install apt dependencies
       run: |
-        sudo apt-get update && apt-get -y install plantuml libxml2-dev libxslt-dev python3-dev
+        sudo apt-get update && sudo apt-get -y install plantuml libxml2-dev libxslt-dev python3-dev
     - name: Install pip dependencies
       run: |
         python -m pip install --upgrade pip

--- a/rst2pdf/genelements.py
+++ b/rst2pdf/genelements.py
@@ -132,7 +132,8 @@ class HandleTGroup(NodeHandler, docutils.nodes.tgroup):
         for x in colWidths:
             # Convert them to %
             w = 100 * x / tot
-            # narrow columns cause strange "huge height" from reportlab, hack for #967
+            # Limit minimum width of a column as narrow columns cause strange "huge height" from reportlab if the cell
+            # padding is larger than the calculated width. Hack for #967
             if w < 4:
                 w = 4
             adjustedWidths.append("%s%%" % w)

--- a/rst2pdf/genelements.py
+++ b/rst2pdf/genelements.py
@@ -127,10 +127,17 @@ class HandleTGroup(NodeHandler, docutils.nodes.tgroup):
                 colWidths.append(int(n['colwidth']))
 
         # colWidths are in no specific unit, really. Maybe ems.
-        # Convert them to %
-        colWidths = [int(x) for x in colWidths]
         tot = sum(colWidths)
-        colWidths = ["%s%%" % ((100.0 * w) / tot) for w in colWidths]
+        adjustedWidths = []
+        for x in colWidths:
+            # Convert them to %
+            w = 100 * x / tot
+            # narrow columns cause strange "huge height" from reportlab, hack for #967
+            if w < 4:
+                w = 4
+            adjustedWidths.append("%s%%" % w)
+
+        colWidths = adjustedWidths
 
         if 'colWidths' in style.__dict__:
             colWidths[: len(style.colWidths)] = style.colWidths

--- a/rst2pdf/tests/input/test_table_narrow_column.rst
+++ b/rst2pdf/tests/input/test_table_narrow_column.rst
@@ -1,0 +1,39 @@
+Automatic sizing of table column widths
+#######################################
+
+If the column is very narrow, it shouldn't fail when ReportLab determines that the width is less than the padding for
+that cell.
+
+= =======================================
+0 Register as a non-blocking blk-mq drive
+1 Register as a blocking blk-mq driver d
+= =======================================
+
+
+.. raw:: pdf
+
+    Spacer 0 20
+
+= ===================================================================================================================
+0 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla at nunc scelerisque, tempor mauris sit amet, feugiat
+1 Register as a blocking blk-mq driver d
+= ===================================================================================================================
+
+
+.. raw:: pdf
+
+    Spacer 0 20
+
+=== =========================================
+00  Register as a non-blocking blk-mq drive
+11  Register as a blocking blk-mq driver d
+=== =========================================
+
+.. raw:: pdf
+
+    Spacer 0 20
+
+=== ======================================
+000 Register as a non-blocking blk-mq drive
+111 Register as a blocking blk-mq driver d
+=== =======================================


### PR DESCRIPTION
Fixes #967  where a table overflows the page. The problem isn't that the table is too large, it's that the column width is smaller than its padding and reportlab doesn't know how to calculate if it will fit in a space when the number is negative so it returns huge dimensions and it overflows.

This PR just makes any column less than 4% of the table be 4%. Sometimes, our tables will be more than 100% as a result, but that hasn't seemed to upset any of the tools. Weirdly none of the tests fail with this change. I'm not sure if we should "bodge" in this way, if it's a useful way to get probably-working tables for most people out of the box, or just one special hack too many. The PR is here for discussion.