### PR TITLE
Add a (temp) fix for a change in black branch naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: psf/black@20.8b1  # change this
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,10 @@ default_language_version:
   # force all unspecified python hooks to run python3
   python: python3
 repos:
-  - repo: https://github.com/ambv/black
-    rev: stable
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    # NOTE(lornajane): Revert to stable when the black project releases a
+    # stable branch https://github.com/psf/black/issues/2079
     hooks:
       - id: black
         # NOTE(stephenfin): This is needed until the fix for


### PR DESCRIPTION
The build errors we saw in the last few days were due to the Black project removing their `stable` branch which is the recommended one to use (see https://github.com/psf/black/issues/2079). This change should fix the build, but we will need to either bump the version number or return to a tracking branch at some future time.