### PR TITLE
Fix usage of deprecated suffix argument in doc2path

### DIFF
--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -413,7 +413,7 @@ class PDFBuilder(Builder):
             if docname not in self.env.all_docs:
                 yield docname
                 continue
-            targetname = self.env.doc2path(docname, self.outdir, self.out_suffix)
+            targetname = os.path.join(self.outdir, docname + self.out_suffix)
             try:
                 targetmtime = os.path.getmtime(targetname)
             except Exception:


### PR DESCRIPTION
Replace call to doc2path with os.path.join as Sphinx did with their
embedded builders.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>