### PR TITLE
Add tests for Sphinx pdf_break_level config option

### DIFF
--- a/rst2pdf/tests/input/sphinx-break-level-0/conf.py
+++ b/rst2pdf/tests/input/sphinx-break-level-0/conf.py
@@ -1,0 +1,17 @@
+# -- General configuration -----------------------------------------------------
+extensions = ['rst2pdf.pdfbuilder']
+master_doc = 'index'
+
+# -- Options for PDF output ----------------------------------------------------
+# Grouping the document tree into PDF files (source start file, target file name, title, author).
+pdf_documents = [('index', 'BreakLevel_0', 'Break Level Test', 'Rob Allen')]
+
+pdf_stylesheets = ['sphinx']
+pdf_use_toc = False
+pdf_use_index = False
+pdf_use_modindex = False
+pdf_use_coverpage = False
+pdf_invariant = True
+pdf_breakside = 'any'
+
+pdf_break_level = 0

--- a/rst2pdf/tests/input/sphinx-break-level-0/index.rst
+++ b/rst2pdf/tests/input/sphinx-break-level-0/index.rst
@@ -1,0 +1,40 @@
+rst2pdf Sphinx pdf_break_level test
+###################################
+
+This test looks at what the pdf_break_level option does.
+
+* ``pdf_break_level = 0``: Everything is on a single page.
+* ``pdf_break_level = 1``: A new page after each section, but not sub-section
+* ``pdf_break_level = 2``: A new page after each section, *and* sub-section
+
+To generate locally, run ``sphinx-build -b pdf . ./pdf``
+
+The next section
+################
+
+This is the next section of the document. This will be on a new page if ``pdf_break_level >= 1``.
+
+The first sub-section
+=====================
+
+This is the first sub-section of the *next section*. This will be on a new page if ``pdf_break_level >= 2``.
+
+The second sub-section
+======================
+
+This is the second sub-section of the *next section*. This will be on a new page if ``pdf_break_level >= 2``.
+
+The section after next
+######################
+
+This is the section after next of the document. This will be on a new page if ``pdf_break_level >= 1``.
+
+Another first sub-section
+=========================
+
+This is the first sub-section of the *section after next*. This will be on a new page if ``pdf_break_level >= 2``.
+
+Another second sub-section
+==========================
+
+This is the second sub-section of the *section after next*. This will be on a new page if ``pdf_break_level >= 2``.

--- a/rst2pdf/tests/input/sphinx-break-level-1/conf.py
+++ b/rst2pdf/tests/input/sphinx-break-level-1/conf.py
@@ -1,0 +1,17 @@
+# -- General configuration -----------------------------------------------------
+extensions = ['rst2pdf.pdfbuilder']
+master_doc = 'index'
+
+# -- Options for PDF output ----------------------------------------------------
+# Grouping the document tree into PDF files (source start file, target file name, title, author).
+pdf_documents = [('index', 'BreakLevel_1', 'Break Level Test', 'Rob Allen')]
+
+pdf_stylesheets = ['sphinx']
+pdf_use_toc = False
+pdf_use_index = False
+pdf_use_modindex = False
+pdf_use_coverpage = False
+pdf_invariant = True
+pdf_breakside = 'any'
+
+pdf_break_level = 1

--- a/rst2pdf/tests/input/sphinx-break-level-1/index.rst
+++ b/rst2pdf/tests/input/sphinx-break-level-1/index.rst
@@ -1,0 +1,40 @@
+rst2pdf Sphinx pdf_break_level test
+###################################
+
+This test looks at what the pdf_break_level option does.
+
+* ``pdf_break_level = 0``: Everything is on a single page.
+* ``pdf_break_level = 1``: A new page after each section, but not sub-section
+* ``pdf_break_level = 2``: A new page after each section, *and* sub-section
+
+To generate locally, run ``sphinx-build -b pdf . ./pdf``
+
+The next section
+################
+
+This is the next section of the document. This will be on a new page if ``pdf_break_level >= 1``.
+
+The first sub-section
+=====================
+
+This is the first sub-section of the *next section*. This will be on a new page if ``pdf_break_level >= 2``.
+
+The second sub-section
+======================
+
+This is the second sub-section of the *next section*. This will be on a new page if ``pdf_break_level >= 2``.
+
+The section after next
+######################
+
+This is the section after next of the document. This will be on a new page if ``pdf_break_level >= 1``.
+
+Another first sub-section
+=========================
+
+This is the first sub-section of the *section after next*. This will be on a new page if ``pdf_break_level >= 2``.
+
+Another second sub-section
+==========================
+
+This is the second sub-section of the *section after next*. This will be on a new page if ``pdf_break_level >= 2``.

--- a/rst2pdf/tests/input/sphinx-break-level-2/conf.py
+++ b/rst2pdf/tests/input/sphinx-break-level-2/conf.py
@@ -1,0 +1,17 @@
+# -- General configuration -----------------------------------------------------
+extensions = ['rst2pdf.pdfbuilder']
+master_doc = 'index'
+
+# -- Options for PDF output ----------------------------------------------------
+# Grouping the document tree into PDF files (source start file, target file name, title, author).
+pdf_documents = [('index', 'BreakLevel_2', 'Break Level Test', 'Rob Allen')]
+
+pdf_stylesheets = ['sphinx']
+pdf_use_toc = False
+pdf_use_index = False
+pdf_use_modindex = False
+pdf_use_coverpage = False
+pdf_invariant = True
+pdf_breakside = 'any'
+
+pdf_break_level = 2

--- a/rst2pdf/tests/input/sphinx-break-level-2/index.rst
+++ b/rst2pdf/tests/input/sphinx-break-level-2/index.rst
@@ -1,0 +1,40 @@
+rst2pdf Sphinx pdf_break_level test
+###################################
+
+This test looks at what the pdf_break_level option does.
+
+* ``pdf_break_level = 0``: Everything is on a single page.
+* ``pdf_break_level = 1``: A new page after each section, but not sub-section
+* ``pdf_break_level = 2``: A new page after each section, *and* sub-section
+
+To generate locally, run ``sphinx-build -b pdf . ./pdf``
+
+The next section
+################
+
+This is the next section of the document. This will be on a new page if ``pdf_break_level >= 1``.
+
+The first sub-section
+=====================
+
+This is the first sub-section of the *next section*. This will be on a new page if ``pdf_break_level >= 2``.
+
+The second sub-section
+======================
+
+This is the second sub-section of the *next section*. This will be on a new page if ``pdf_break_level >= 2``.
+
+The section after next
+######################
+
+This is the section after next of the document. This will be on a new page if ``pdf_break_level >= 1``.
+
+Another first sub-section
+=========================
+
+This is the first sub-section of the *section after next*. This will be on a new page if ``pdf_break_level >= 2``.
+
+Another second sub-section
+==========================
+
+This is the second sub-section of the *section after next*. This will be on a new page if ``pdf_break_level >= 2``.

--- a/rst2pdf/tests/reference/sphinx-break-level-0.pdf
+++ b/rst2pdf/tests/reference/sphinx-break-level-0.pdf
@@ -1,0 +1,364 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Outlines 9 0 R /PageLabels 19 0 R /PageMode /UseNone /Pages 17 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title () /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 9 /First 10 0 R /Last 14 0 R /Type /Outlines
+>>
+endobj
+10 0 obj
+<<
+/Dest [ 6 0 R /XYZ 40.01575 799.0394 0 ] /Next 11 0 R /Parent 9 0 R /Title (rst2pdf Sphinx pdf_break_level test)
+>>
+endobj
+11 0 obj
+<<
+/Count 2 /Dest [ 6 0 R /XYZ 40.01575 669.0394 0 ] /First 12 0 R /Last 13 0 R /Next 14 0 R /Parent 9 0 R 
+  /Prev 10 0 R /Title (The next section)
+>>
+endobj
+12 0 obj
+<<
+/Dest [ 6 0 R /XYZ 40.01575 611.0394 0 ] /Next 13 0 R /Parent 11 0 R /Title (The first sub-section)
+>>
+endobj
+13 0 obj
+<<
+/Dest [ 6 0 R /XYZ 40.01575 557.8394 0 ] /Parent 11 0 R /Prev 12 0 R /Title (The second sub-section)
+>>
+endobj
+14 0 obj
+<<
+/Count 2 /Dest [ 6 0 R /XYZ 40.01575 504.6394 0 ] /First 15 0 R /Last 16 0 R /Parent 9 0 R /Prev 11 0 R 
+  /Title (The section after next)
+>>
+endobj
+15 0 obj
+<<
+/Dest [ 6 0 R /XYZ 40.01575 446.6394 0 ] /Next 16 0 R /Parent 14 0 R /Title (Another first sub-section)
+>>
+endobj
+16 0 obj
+<<
+/Dest [ 6 0 R /XYZ 40.01575 393.4394 0 ] /Parent 14 0 R /Prev 15 0 R /Title (Another second sub-section)
+>>
+endobj
+17 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+18 0 obj
+<<
+/Length 4772
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (rst2pdf Sphinx pdf_break_level test) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This test looks at what the pdf_break_level option does.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 751.0394 cm
+Q
+q
+1 0 0 1 40.01575 751.0394 cm
+Q
+q
+1 0 0 1 40.01575 739.0394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (pdf_break_level) Tj ( ) Tj (=) Tj ( ) Tj (0) Tj /F1 10 Tf (: Everything is on a single page.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 733.0394 cm
+Q
+q
+1 0 0 1 40.01575 721.0394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (pdf_break_level) Tj ( ) Tj (=) Tj ( ) Tj (1) Tj /F1 10 Tf (: A new page after each section, but not sub-section) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 715.0394 cm
+Q
+q
+1 0 0 1 40.01575 703.0394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (pdf_break_level) Tj ( ) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (: A new page after each section, ) Tj /F4 10 Tf (and) Tj /F1 10 Tf ( sub-section) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 703.0394 cm
+Q
+q
+1 0 0 1 40.01575 685.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (To generate locally, run ) Tj /F3 10 Tf (sphinx-build) Tj ( ) Tj (-b) Tj ( ) Tj (pdf) Tj ( ) Tj (.) Tj ( ) Tj (./pdf) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 645.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (The next section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 627.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the next section of the document. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (1) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 591.8394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (The first sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 573.8394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the first sub-section of the ) Tj /F4 10 Tf (next section) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 538.6394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (The second sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 520.6394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the second sub-section of the ) Tj /F4 10 Tf (next section) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 480.6394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (The section after next) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 462.6394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the section after next of the document. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (1) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 427.4394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (Another first sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 409.4394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the first sub-section of the ) Tj /F4 10 Tf (section after next) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 374.2394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (Another second sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 356.2394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the second sub-section of the ) Tj /F4 10 Tf (section after next) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+19 0 obj
+<<
+/Nums [ 0 20 0 R ]
+>>
+endobj
+20 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+xref
+0 21
+0000000000 65535 f 
+0000000073 00000 n 
+0000000134 00000 n 
+0000000241 00000 n 
+0000000353 00000 n 
+0000000458 00000 n 
+0000000573 00000 n 
+0000000778 00000 n 
+0000000882 00000 n 
+0000001139 00000 n 
+0000001212 00000 n 
+0000001347 00000 n 
+0000001515 00000 n 
+0000001637 00000 n 
+0000001760 00000 n 
+0000001921 00000 n 
+0000002047 00000 n 
+0000002174 00000 n 
+0000002234 00000 n 
+0000007058 00000 n 
+0000007099 00000 n 
+trailer
+<<
+/ID 
+[<2db82f8d13fc9aad0f6ac8c1445975f3><2db82f8d13fc9aad0f6ac8c1445975f3>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 21
+>>
+startxref
+7133
+%%EOF

--- a/rst2pdf/tests/reference/sphinx-break-level-1.pdf
+++ b/rst2pdf/tests/reference/sphinx-break-level-1.pdf
@@ -1,0 +1,424 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Outlines 11 0 R /PageLabels 23 0 R /PageMode /UseNone /Pages 19 0 R /Type /Catalog
+>>
+endobj
+10 0 obj
+<<
+/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title () /Trapped /False
+>>
+endobj
+11 0 obj
+<<
+/Count 9 /First 12 0 R /Last 16 0 R /Type /Outlines
+>>
+endobj
+12 0 obj
+<<
+/Dest [ 6 0 R /XYZ 40.01575 799.0394 0 ] /Next 13 0 R /Parent 11 0 R /Title (rst2pdf Sphinx pdf_break_level test)
+>>
+endobj
+13 0 obj
+<<
+/Count 2 /Dest [ 7 0 R /XYZ 40.01575 799.0394 0 ] /First 14 0 R /Last 15 0 R /Next 16 0 R /Parent 11 0 R 
+  /Prev 12 0 R /Title (The next section)
+>>
+endobj
+14 0 obj
+<<
+/Dest [ 7 0 R /XYZ 40.01575 741.0394 0 ] /Next 15 0 R /Parent 13 0 R /Title (The first sub-section)
+>>
+endobj
+15 0 obj
+<<
+/Dest [ 7 0 R /XYZ 40.01575 687.8394 0 ] /Parent 13 0 R /Prev 14 0 R /Title (The second sub-section)
+>>
+endobj
+16 0 obj
+<<
+/Count 2 /Dest [ 8 0 R /XYZ 40.01575 799.0394 0 ] /First 17 0 R /Last 18 0 R /Parent 11 0 R /Prev 13 0 R 
+  /Title (The section after next)
+>>
+endobj
+17 0 obj
+<<
+/Dest [ 8 0 R /XYZ 40.01575 741.0394 0 ] /Next 18 0 R /Parent 16 0 R /Title (Another first sub-section)
+>>
+endobj
+18 0 obj
+<<
+/Dest [ 8 0 R /XYZ 40.01575 687.8394 0 ] /Parent 16 0 R /Prev 17 0 R /Title (Another second sub-section)
+>>
+endobj
+19 0 obj
+<<
+/Count 3 /Kids [ 6 0 R 7 0 R 8 0 R ] /Type /Pages
+>>
+endobj
+20 0 obj
+<<
+/Length 1903
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (rst2pdf Sphinx pdf_break_level test) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This test looks at what the pdf_break_level option does.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 751.0394 cm
+Q
+q
+1 0 0 1 40.01575 751.0394 cm
+Q
+q
+1 0 0 1 40.01575 739.0394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (pdf_break_level) Tj ( ) Tj (=) Tj ( ) Tj (0) Tj /F1 10 Tf (: Everything is on a single page.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 733.0394 cm
+Q
+q
+1 0 0 1 40.01575 721.0394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (pdf_break_level) Tj ( ) Tj (=) Tj ( ) Tj (1) Tj /F1 10 Tf (: A new page after each section, but not sub-section) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 715.0394 cm
+Q
+q
+1 0 0 1 40.01575 703.0394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (pdf_break_level) Tj ( ) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (: A new page after each section, ) Tj /F4 10 Tf (and) Tj /F1 10 Tf ( sub-section) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 703.0394 cm
+Q
+q
+1 0 0 1 40.01575 685.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (To generate locally, run ) Tj /F3 10 Tf (sphinx-build) Tj ( ) Tj (-b) Tj ( ) Tj (pdf) Tj ( ) Tj (.) Tj ( ) Tj (./pdf) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 685.0394 cm
+Q
+ 
+endstream
+endobj
+21 0 obj
+<<
+/Length 1510
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (The next section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the next section of the document. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (1) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 721.8394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (The first sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 703.8394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the first sub-section of the ) Tj /F4 10 Tf (next section) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 668.6394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (The second sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 650.6394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the second sub-section of the ) Tj /F4 10 Tf (next section) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 650.6394 cm
+Q
+ 
+endstream
+endobj
+22 0 obj
+<<
+/Length 1509
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (The section after next) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the section after next of the document. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (1) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 721.8394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (Another first sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 703.8394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the first sub-section of the ) Tj /F4 10 Tf (section after next) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 668.6394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (Another second sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 650.6394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the second sub-section of the ) Tj /F4 10 Tf (section after next) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+23 0 obj
+<<
+/Nums [ 0 24 0 R 1 25 0 R 2 26 0 R ]
+>>
+endobj
+24 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+25 0 obj
+<<
+/S /D /St 2
+>>
+endobj
+26 0 obj
+<<
+/S /D /St 3
+>>
+endobj
+xref
+0 27
+0000000000 65535 f 
+0000000073 00000 n 
+0000000134 00000 n 
+0000000241 00000 n 
+0000000353 00000 n 
+0000000458 00000 n 
+0000000573 00000 n 
+0000000778 00000 n 
+0000000983 00000 n 
+0000001188 00000 n 
+0000001293 00000 n 
+0000001551 00000 n 
+0000001625 00000 n 
+0000001761 00000 n 
+0000001930 00000 n 
+0000002052 00000 n 
+0000002175 00000 n 
+0000002337 00000 n 
+0000002463 00000 n 
+0000002590 00000 n 
+0000002662 00000 n 
+0000004617 00000 n 
+0000006179 00000 n 
+0000007740 00000 n 
+0000007799 00000 n 
+0000007833 00000 n 
+0000007867 00000 n 
+trailer
+<<
+/ID 
+[<2db82f8d13fc9aad0f6ac8c1445975f3><2db82f8d13fc9aad0f6ac8c1445975f3>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 10 0 R
+/Root 9 0 R
+/Size 27
+>>
+startxref
+7901
+%%EOF

--- a/rst2pdf/tests/reference/sphinx-break-level-2.pdf
+++ b/rst2pdf/tests/reference/sphinx-break-level-2.pdf
@@ -1,0 +1,545 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 28 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 29 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 30 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/Outlines 15 0 R /PageLabels 31 0 R /PageMode /UseNone /Pages 23 0 R /Type /Catalog
+>>
+endobj
+14 0 obj
+<<
+/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title () /Trapped /False
+>>
+endobj
+15 0 obj
+<<
+/Count 9 /First 16 0 R /Last 20 0 R /Type /Outlines
+>>
+endobj
+16 0 obj
+<<
+/Dest [ 6 0 R /XYZ 40.01575 799.0394 0 ] /Next 17 0 R /Parent 15 0 R /Title (rst2pdf Sphinx pdf_break_level test)
+>>
+endobj
+17 0 obj
+<<
+/Count 2 /Dest [ 7 0 R /XYZ 40.01575 799.0394 0 ] /First 18 0 R /Last 19 0 R /Next 20 0 R /Parent 15 0 R 
+  /Prev 16 0 R /Title (The next section)
+>>
+endobj
+18 0 obj
+<<
+/Dest [ 8 0 R /XYZ 40.01575 799.0394 0 ] /Next 19 0 R /Parent 17 0 R /Title (The first sub-section)
+>>
+endobj
+19 0 obj
+<<
+/Dest [ 9 0 R /XYZ 40.01575 799.0394 0 ] /Parent 17 0 R /Prev 18 0 R /Title (The second sub-section)
+>>
+endobj
+20 0 obj
+<<
+/Count 2 /Dest [ 10 0 R /XYZ 40.01575 799.0394 0 ] /First 21 0 R /Last 22 0 R /Parent 15 0 R /Prev 17 0 R 
+  /Title (The section after next)
+>>
+endobj
+21 0 obj
+<<
+/Dest [ 11 0 R /XYZ 40.01575 799.0394 0 ] /Next 22 0 R /Parent 20 0 R /Title (Another first sub-section)
+>>
+endobj
+22 0 obj
+<<
+/Dest [ 12 0 R /XYZ 40.01575 799.0394 0 ] /Parent 20 0 R /Prev 21 0 R /Title (Another second sub-section)
+>>
+endobj
+23 0 obj
+<<
+/Count 7 /Kids [ 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R ] /Type /Pages
+>>
+endobj
+24 0 obj
+<<
+/Length 1903
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (rst2pdf Sphinx pdf_break_level test) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This test looks at what the pdf_break_level option does.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 751.0394 cm
+Q
+q
+1 0 0 1 40.01575 751.0394 cm
+Q
+q
+1 0 0 1 40.01575 739.0394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (pdf_break_level) Tj ( ) Tj (=) Tj ( ) Tj (0) Tj /F1 10 Tf (: Everything is on a single page.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 733.0394 cm
+Q
+q
+1 0 0 1 40.01575 721.0394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (pdf_break_level) Tj ( ) Tj (=) Tj ( ) Tj (1) Tj /F1 10 Tf (: A new page after each section, but not sub-section) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 715.0394 cm
+Q
+q
+1 0 0 1 40.01575 703.0394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (pdf_break_level) Tj ( ) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (: A new page after each section, ) Tj /F4 10 Tf (and) Tj /F1 10 Tf ( sub-section) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 703.0394 cm
+Q
+q
+1 0 0 1 40.01575 685.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (To generate locally, run ) Tj /F3 10 Tf (sphinx-build) Tj ( ) Tj (-b) Tj ( ) Tj (pdf) Tj ( ) Tj (.) Tj ( ) Tj (./pdf) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 685.0394 cm
+Q
+ 
+endstream
+endobj
+25 0 obj
+<<
+/Length 518
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (The next section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the next section of the document. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (1) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+Q
+ 
+endstream
+endobj
+26 0 obj
+<<
+/Length 570
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 779.8394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (The first sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 761.8394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the first sub-section of the ) Tj /F4 10 Tf (next section) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 761.8394 cm
+Q
+ 
+endstream
+endobj
+27 0 obj
+<<
+/Length 572
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 779.8394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (The second sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 761.8394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the second sub-section of the ) Tj /F4 10 Tf (next section) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 761.8394 cm
+Q
+ 
+endstream
+endobj
+28 0 obj
+<<
+/Length 530
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (The section after next) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the section after next of the document. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (1) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+Q
+ 
+endstream
+endobj
+29 0 obj
+<<
+/Length 580
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 779.8394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (Another first sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 761.8394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the first sub-section of the ) Tj /F4 10 Tf (section after next) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 761.8394 cm
+Q
+ 
+endstream
+endobj
+30 0 obj
+<<
+/Length 549
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 779.8394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 25.2 re B*
+Q
+q
+BT 1 0 0 1 0 3.2 Tm 19.2 TL /F2 16 Tf .12549 .262745 .360784 rg (Another second sub-section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 761.8394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This is the second sub-section of the ) Tj /F4 10 Tf (section after next) Tj /F1 10 Tf (. This will be on a new page if ) Tj /F3 10 Tf (pdf_break_level) Tj ( ) Tj (>) Tj (=) Tj ( ) Tj (2) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+31 0 obj
+<<
+/Nums [ 0 32 0 R 1 33 0 R 2 34 0 R 3 35 0 R 4 36 0 R 
+  5 37 0 R 6 38 0 R ]
+>>
+endobj
+32 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+33 0 obj
+<<
+/S /D /St 2
+>>
+endobj
+34 0 obj
+<<
+/S /D /St 3
+>>
+endobj
+35 0 obj
+<<
+/S /D /St 4
+>>
+endobj
+36 0 obj
+<<
+/S /D /St 5
+>>
+endobj
+37 0 obj
+<<
+/S /D /St 6
+>>
+endobj
+38 0 obj
+<<
+/S /D /St 7
+>>
+endobj
+xref
+0 39
+0000000000 65535 f 
+0000000073 00000 n 
+0000000134 00000 n 
+0000000241 00000 n 
+0000000353 00000 n 
+0000000458 00000 n 
+0000000573 00000 n 
+0000000778 00000 n 
+0000000983 00000 n 
+0000001188 00000 n 
+0000001393 00000 n 
+0000001599 00000 n 
+0000001805 00000 n 
+0000002011 00000 n 
+0000002117 00000 n 
+0000002375 00000 n 
+0000002449 00000 n 
+0000002585 00000 n 
+0000002754 00000 n 
+0000002876 00000 n 
+0000002999 00000 n 
+0000003162 00000 n 
+0000003289 00000 n 
+0000003417 00000 n 
+0000003516 00000 n 
+0000005471 00000 n 
+0000006040 00000 n 
+0000006661 00000 n 
+0000007284 00000 n 
+0000007865 00000 n 
+0000008496 00000 n 
+0000009096 00000 n 
+0000009194 00000 n 
+0000009228 00000 n 
+0000009262 00000 n 
+0000009296 00000 n 
+0000009330 00000 n 
+0000009364 00000 n 
+0000009398 00000 n 
+trailer
+<<
+/ID 
+[<2db82f8d13fc9aad0f6ac8c1445975f3><2db82f8d13fc9aad0f6ac8c1445975f3>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 14 0 R
+/Root 13 0 R
+/Size 39
+>>
+startxref
+9432
+%%EOF


### PR DESCRIPTION
This is a set of tests that show how the `pdf_break_level` option affects the same document.

 As useful for documentation as for proving it works, I think but equally it could be argued that this would be better in the manual or on the website.
