### PR TITLE
Add more progress information to --very-verbose

### DIFF
--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -663,6 +663,7 @@ class RstToPdf(object):
         while True:
             try:
                 log.info("Starting build")
+                self.elements = elements
                 # See if this *must* be multipass
                 pdfdoc.multiBuild(elements)
                 # Force a multibuild pass
@@ -731,6 +732,23 @@ class RstToPdf(object):
 
 
 class FancyDocTemplate(BaseDocTemplate):
+    def onProgress(self, typ, value):
+        global _counter
+        message = ''
+        if typ == 'SIZE_EST':
+            log.debug(f'Number of flowables: {value}')
+        elif typ == 'PROGRESS':
+            message = f'Flowable {value}'
+            # add class name for this flowable if we can
+            if hasattr(self.client, 'elements'):
+                if 0 <= value < len(self.client.elements):
+                    element = self.client.elements[value]
+                    message += f" {type(element)}"
+            log.debug(f'Page {_counter}: {message}')
+
+    def afterInit(self):
+        self.setProgressCallBack(self.onProgress)
+
     def afterFlowable(self, flowable):
 
         if isinstance(flowable, Heading):


### PR DESCRIPTION
When ReportLab builds the PDF, hook into the onProgress callback and display progress information when using --very-verbose. This will hopefully make it a little bit easier to determine what has gone wrong.

For example when an image in a `figure` is too large you will get a "Likely that a flowable is too large for any frame" error.

This is the relevant part of the output:

```
INFO] createpdf.py:665 Starting build
[DEBUG] createpdf.py:739 Number of flowables: 6
[DEBUG] createpdf.py:747 Page 1: Flowable 1 <class 'reportlab.platypus.paragraph.Paragraph'>
[DEBUG] createpdf.py:747 Page 1: Flowable 2 <class 'reportlab.platypus.paragraph.Paragraph'>
[DEBUG] createpdf.py:747 Page 1: Flowable 3 <class 'rst2pdf.flowables.MySpacer'>
[DEBUG] createpdf.py:747 Page 1: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[WARNING] image.py:423 Image /Users/rob/Projects/python/rst2pdf/rst2pdf/tests/input/images/background.jpg is too wide for the frame, rescaling
[INFO] createpdf.py:1193 Page 1 [1]
[DEBUG] createpdf.py:747 Page 1: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[INFO] createpdf.py:1193 Page 2 [2]
[DEBUG] createpdf.py:747 Page 2: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[INFO] createpdf.py:1193 Page 3 [3]
[DEBUG] createpdf.py:747 Page 3: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[INFO] createpdf.py:1193 Page 4 [4]
[DEBUG] createpdf.py:747 Page 4: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[INFO] createpdf.py:1193 Page 5 [5]
[DEBUG] createpdf.py:747 Page 5: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[INFO] createpdf.py:1193 Page 6 [6]
[DEBUG] createpdf.py:747 Page 6: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[INFO] createpdf.py:1193 Page 7 [7]
[DEBUG] createpdf.py:747 Page 7: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[INFO] createpdf.py:1193 Page 8 [8]
[DEBUG] createpdf.py:747 Page 8: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[INFO] createpdf.py:1193 Page 9 [9]
[DEBUG] createpdf.py:747 Page 9: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
[INFO] createpdf.py:1193 Page 10 [10]
[DEBUG] createpdf.py:747 Page 10: Flowable 4 <class 'rst2pdf.flowables.DelayedTable'>
Traceback (most recent call last):
  File "/Users/rob/.pyenv/versions/rst2pdf-395/bin/rst2pdf", line 33, in <module>
    sys.exit(load_entry_point('rst2pdf', 'console_scripts', 'rst2pdf')())
  File "/Users/rob/Projects/python/rst2pdf/rst2pdf/createpdf.py", line 1723, in main
    return_code = RstToPdf(
  File "/Users/rob/Projects/python/rst2pdf/rst2pdf/createpdf.py", line 668, in createPdf
    pdfdoc.multiBuild(elements)
  File "/Users/rob/.pyenv/versions/3.9.5/envs/rst2pdf-395/lib/python3.9/site-packages/reportlab/platypus/doctemplate.py", line 1166, in multiBuild
    self.build(tempStory, **buildKwds)
  File "/Users/rob/.pyenv/versions/3.9.5/envs/rst2pdf-395/lib/python3.9/site-packages/reportlab/platypus/doctemplate.py", line 1079, in build
    self.handle_flowable(flowables)
  File "/Users/rob/Projects/python/rst2pdf/rst2pdf/createpdf.py", line 839, in handle_flowable
    self.handle_frameEnd()
  File "/Users/rob/.pyenv/versions/3.9.5/envs/rst2pdf-395/lib/python3.9/site-packages/reportlab/platypus/doctemplate.py", line 725, in handle_frameEnd
    self.handle_pageEnd()
  File "/Users/rob/.pyenv/versions/3.9.5/envs/rst2pdf-395/lib/python3.9/site-packages/reportlab/platypus/doctemplate.py", line 667, in handle_pageEnd
    raise LayoutError(ident)
reportlab.platypus.doctemplate.LayoutError: More than 10 pages generated without content - halting layout.  Likely that a flowable is too large for any frame.
```

So we can see we're looking for a "DelayedTable" after the first two paragraphs of text. Of course, unfortunately, you still need to know the underlying structure of the doctree that rst2pdf has built and that a `figure` is a `DelayedTable` surrounded by two `MySpacer`s.

Hopefully better than what we currently have though!

Fixes #944
