### PR TITLE
Add Python 3.10 to CI & update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
         experimental: [false]
 
     steps:

--- a/requirements.3.6.txt
+++ b/requirements.3.6.txt
@@ -16,11 +16,11 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.9
     # via requests
 cssselect2==0.4.1
     # via svglib
-cycler==0.10.0
+cycler==0.11.0
     # via matplotlib
 docutils==0.17.1
     # via
@@ -30,26 +30,26 @@ future==0.18.2
     # via arabic-reshaper
 html5lib==1.1
     # via xhtml2pdf
-httplib2==0.20.1
+httplib2==0.20.2
     # via plantuml
-idna==3.2
+idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.8.1
+importlib-metadata==4.8.2
     # via
     #   pluggy
     #   pytest
     #   rst2pdf (setup.py)
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   rst2pdf (setup.py)
     #   sphinx
 kiwisolver==1.3.1
     # via matplotlib
-lxml==4.6.3
+lxml==4.6.4
     # via svglib
 markupsafe==2.0.1
     # via jinja2
@@ -57,12 +57,12 @@ matplotlib==3.3.4
     # via rst2pdf (setup.py)
 numpy==1.19.5
     # via matplotlib
-packaging==21.0
+packaging==21.3
     # via
     #   pytest
     #   rst2pdf (setup.py)
     #   sphinx
-pillow==8.3.2
+pillow==8.4.0
     # via
     #   matplotlib
     #   reportlab
@@ -71,15 +71,15 @@ plantuml==0.3.0
     # via rst2pdf (setup.py)
 pluggy==1.0.0
     # via pytest
-py==1.10.0
+py==1.11.0
     # via pytest
 pygments==2.10.0
     # via
     #   rst2pdf (setup.py)
     #   sphinx
-pymupdf==1.18.19
+pymupdf==1.19.3
     # via rst2pdf (setup.py)
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   httplib2
     #   matplotlib
@@ -94,9 +94,9 @@ python-dateutil==2.8.2
     # via matplotlib
 pytz==2021.3
     # via babel
-pyyaml==5.4.1
+pyyaml==6.0
     # via rst2pdf (setup.py)
-reportlab==3.6.1
+reportlab==3.6.3
     # via
     #   rst2pdf (setup.py)
     #   svglib
@@ -105,16 +105,15 @@ requests==2.26.0
     # via sphinx
 six==1.16.0
     # via
-    #   cycler
     #   html5lib
     #   python-bidi
     #   python-dateutil
     #   xhtml2pdf
 smartypants==2.0.1
     # via rst2pdf (setup.py)
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.1
     # via rst2pdf (setup.py)
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -130,13 +129,13 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 svglib==1.1.0
     # via rst2pdf (setup.py)
-tinycss2==1.1.0
+tinycss2==1.1.1
     # via
     #   cssselect2
     #   svglib
 toml==0.10.2
     # via pytest
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via importlib-metadata
 urllib3==1.26.7
     # via requests

--- a/requirements.3.7.txt
+++ b/requirements.3.7.txt
@@ -16,53 +16,56 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.9
     # via requests
 cssselect2==0.4.1
     # via svglib
-cycler==0.10.0
+cycler==0.11.0
     # via matplotlib
 docutils==0.17.1
     # via
     #   rst2pdf (setup.py)
     #   sphinx
+fonttools==4.28.3
+    # via matplotlib
 future==0.18.2
     # via arabic-reshaper
 html5lib==1.1
     # via xhtml2pdf
-httplib2==0.20.1
+httplib2==0.20.2
     # via plantuml
-idna==3.2
+idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.8.1
+importlib-metadata==4.8.2
     # via
     #   pluggy
     #   pytest
     #   rst2pdf (setup.py)
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   rst2pdf (setup.py)
     #   sphinx
 kiwisolver==1.3.2
     # via matplotlib
-lxml==4.6.3
+lxml==4.6.4
     # via svglib
 markupsafe==2.0.1
     # via jinja2
-matplotlib==3.4.3
+matplotlib==3.5.1
     # via rst2pdf (setup.py)
-numpy==1.21.2
+numpy==1.21.4
     # via matplotlib
-packaging==21.0
+packaging==21.3
     # via
+    #   matplotlib
     #   pytest
     #   rst2pdf (setup.py)
     #   sphinx
-pillow==8.3.2
+pillow==8.4.0
     # via
     #   matplotlib
     #   reportlab
@@ -71,15 +74,15 @@ plantuml==0.3.0
     # via rst2pdf (setup.py)
 pluggy==1.0.0
     # via pytest
-py==1.10.0
+py==1.11.0
     # via pytest
 pygments==2.10.0
     # via
     #   rst2pdf (setup.py)
     #   sphinx
-pymupdf==1.18.19
+pymupdf==1.19.3
     # via rst2pdf (setup.py)
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   httplib2
     #   matplotlib
@@ -94,9 +97,9 @@ python-dateutil==2.8.2
     # via matplotlib
 pytz==2021.3
     # via babel
-pyyaml==5.4.1
+pyyaml==6.0
     # via rst2pdf (setup.py)
-reportlab==3.6.1
+reportlab==3.6.3
     # via
     #   rst2pdf (setup.py)
     #   svglib
@@ -105,16 +108,15 @@ requests==2.26.0
     # via sphinx
 six==1.16.0
     # via
-    #   cycler
     #   html5lib
     #   python-bidi
     #   python-dateutil
     #   xhtml2pdf
 smartypants==2.0.1
     # via rst2pdf (setup.py)
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.1
     # via rst2pdf (setup.py)
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -130,13 +132,13 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 svglib==1.1.0
     # via rst2pdf (setup.py)
-tinycss2==1.1.0
+tinycss2==1.1.1
     # via
     #   cssselect2
     #   svglib
 toml==0.10.2
     # via pytest
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via importlib-metadata
 urllib3==1.26.7
     # via requests

--- a/rst2pdf/tests/conftest.py
+++ b/rst2pdf/tests/conftest.py
@@ -57,7 +57,7 @@ def _get_pages(pdf):
     pages = []
 
     for page in pdf.pages():
-        pages.append(page.getText('blocks'))
+        pages.append(page.get_text('blocks'))
 
     return pages
 


### PR DESCRIPTION
Add Python 3.10 to the CI matrix.

Update dependencies specified in requirements.3.x.txt. We can continue to use the 3.7 requirements for 3.8, 3.9 & 3.10.