### PR TITLE
Support pdf_smartquotes config option for Sphinx

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2038,6 +2038,9 @@ To use it in your existing Sphinx project you need to do the following:
     # Repeat table header on tables that cross a page boundary?
     pdf_repeat_table_rows = True
 
+    # Enable smart quotes (1, 2 or 3) or disable by setting to 0
+    pdf_smartquotes = 0
+
 3. (Optional) Modify your ``Makefile`` or ``make.bat`` file
 
     For ``Makefile`` (on \*nix systems)

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -132,6 +132,9 @@ class PDFBuilder(Builder):
                     section_header_depth=opts.get(
                         'section_header_depth', self.config.section_header_depth
                     ),
+                    smartquotes=str(
+                        opts.get('pdf_smartquotes', self.config.pdf_smartquotes)
+                    ),
                     srcdir=self.srcdir,
                     style_path=opts.get('pdf_style_path', self.config.pdf_style_path),
                     config=self.config,
@@ -560,6 +563,7 @@ class PDFWriter(writers.Writer):
         baseurl=urlunparse(['file', os.getcwd() + os.sep, '', '', '', '']),
         style_path=None,
         repeat_table_rows=False,
+        smartquotes='0',
         config={},
     ):
         writers.Writer.__init__(self)
@@ -588,6 +592,7 @@ class PDFWriter(writers.Writer):
         self.fit_background_mode = fit_background_mode
         self.section_header_depth = section_header_depth
         self.repeat_table_rows = repeat_table_rows
+        self.smartquotes = smartquotes
         self.baseurl = baseurl
         if hasattr(sys, 'frozen'):
             self.PATH = os.path.abspath(os.path.dirname(sys.executable))
@@ -709,6 +714,7 @@ class PDFWriter(writers.Writer):
             background_fit_mode=self.fit_background_mode,
             baseurl=self.baseurl,
             section_header_depth=self.section_header_depth,
+            smarty=self.smartquotes,
         ).createPdf(doctree=self.document, output=sio, compressed=self.compressed)
         self.output = sio.getvalue()
 
@@ -979,6 +985,7 @@ def setup(app):
     app.add_config_value('pdf_toc_depth', 9999, None)
     app.add_config_value('pdf_use_numbered_links', False, None)
     app.add_config_value('pdf_fit_background_mode', "scale", None)
+    app.add_config_value('pdf_smartquotes', 0, None)
     app.add_config_value('section_header_depth', 2, None)
     app.add_config_value(
         'pdf_baseurl', urlunparse(['file', os.getcwd() + os.sep, '', '', '', '']), None

--- a/rst2pdf/tests/input/sphinx-smartquotes/conf.py
+++ b/rst2pdf/tests/input/sphinx-smartquotes/conf.py
@@ -1,0 +1,17 @@
+# -- General configuration -----------------------------------------------------
+extensions = ['rst2pdf.pdfbuilder']
+master_doc = 'index'
+
+# -- Options for PDF output ----------------------------------------------------
+# Grouping the document tree into PDF files (source start file, target file name, title, author).
+pdf_documents = [('index', 'BreakLevel_0', 'Break Level Test', 'Rob Allen')]
+
+pdf_stylesheets = ['sphinx']
+pdf_use_toc = False
+pdf_use_index = False
+pdf_use_modindex = False
+pdf_use_coverpage = False
+pdf_invariant = True
+pdf_breakside = 'any'
+
+pdf_smartquotes = 2

--- a/rst2pdf/tests/input/sphinx-smartquotes/index.rst
+++ b/rst2pdf/tests/input/sphinx-smartquotes/index.rst
@@ -1,0 +1,14 @@
+rst2pdf Sphinx pdf_smartquotes test
+###################################
+
+This test ensures that the ``pdf_smartquotes`` config option works.
+
+A -- B
+
+A --- B
+
+"A B"
+
+A ... B
+
+\`\`A B''

--- a/rst2pdf/tests/reference/sphinx-smartquotes.pdf
+++ b/rst2pdf/tests/reference/sphinx-smartquotes.pdf
@@ -1,0 +1,158 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Outlines 8 0 R /PageLabels 12 0 R /PageMode /UseNone /Pages 10 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title () /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 1 /First 9 0 R /Last 9 0 R /Type /Outlines
+>>
+endobj
+9 0 obj
+<<
+/Dest [ 5 0 R /XYZ 40.01575 799.0394 0 ] /Parent 8 0 R /Title (rst2pdf Sphinx pdf_smartquotes test)
+>>
+endobj
+10 0 obj
+<<
+/Count 1 /Kids [ 5 0 R ] /Type /Pages
+>>
+endobj
+11 0 obj
+<<
+/Length 970
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (rst2pdf Sphinx pdf_smartquotes test) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 757.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This test ensures that the ) Tj /F3 10 Tf (pdf_smartquotes) Tj /F1 10 Tf ( config option works.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 739.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \226 B) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 721.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \227 B) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 703.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 685.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 667.0394 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (\221) Tj (\221) Tj (A B\222\222) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+12 0 obj
+<<
+/Nums [ 0 13 0 R ]
+>>
+endobj
+13 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+xref
+0 14
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000448 00000 n 
+0000000653 00000 n 
+0000000757 00000 n 
+0000001014 00000 n 
+0000001085 00000 n 
+0000001206 00000 n 
+0000001266 00000 n 
+0000002287 00000 n 
+0000002328 00000 n 
+trailer
+<<
+/ID 
+[<2db82f8d13fc9aad0f6ac8c1445975f3><2db82f8d13fc9aad0f6ac8c1445975f3>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 14
+>>
+startxref
+2362
+%%EOF


### PR DESCRIPTION
Allow configuration of smart quotes using smartypants from Sphinx as we can for CLI (--smartquotes) with the config option `pdf_smartquotes`.

Closes #545 
