### PR TITLE
Log docutils error on failure

### DIFF
--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -543,7 +543,12 @@ class RstToPdf(object):
                         settings_overrides=settings_overrides,
                     )
                     log.debug(self.doctree)
-                except Exception:
+                except Exception as e:
+                    if log.isEnabledFor(logging.INFO):
+                        # Log exception with traceback if more detailed logging has been set
+                        log.exception('Error generating doctree')
+                    else:
+                        log.error(f"Error generating doctree: {e}")
                     log.error("Cannot generate PDF, exiting")
                     return 1
             else:


### PR DESCRIPTION
For some errors when publishing the doctree, it's unclear what has gone wrong as the reason is only in the exception message. Therefore we now log this this message.  If verbose or very-verbose logging has been requested, also include the traceback.
