### PR TITLE
Update release info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,9 @@
 {next}
 ------
 
+0.99 (2022-01-08)
+-----------------
+
 * Added: Python 3.9 & 3.10 are now supported (PR #969, #1043)
 * Added: Sphinx 4 is now supported. (PR #1020)
 * Added: Can now set background images using ``PageBreak``. (PR #1050)

--- a/doc/RELEASE_PROCESS.rst
+++ b/doc/RELEASE_PROCESS.rst
@@ -4,7 +4,12 @@ Release Process for rst2pdf
 
 This is an outline of what needs to be done in order to release rst2pdf.
 
-#. Update ``CHANGES.rst``. Commit to a branch, PR and merge to master
+#. Install dependencies that you'll need
+   ::
+
+      $ pip install setuptools setuptools_scm wheel twine
+
+#. Update ``CHANGES.rst`` to add the version number and date. Commit to a branch, PR and merge to master
 #. Ensure all PRs are attached to the milestone
 #. Close the milestone and create next one
 #. Use changelog-generator_ (or similar) to create a changelog
@@ -102,7 +107,7 @@ It should contain the following:
 .. _rst2pdf.github.io: https://github.com/rst2pdf/rst2pdf.github.io
 .. _changelog-generator: https://github.com/weierophinney/changelog_generator
 .. _Test-PyPI: https://test.pypi.org
-.. _PyPI: https://test.pypi.org
+.. _PyPI: https://pypi.org
 
 
 Releasing as a Snap

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Documentation',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Processing',


### PR DESCRIPTION
A couple of things found while releasing 0.99:

- Add Python 3.9 and 3.10 to PyPI's classifiers
- Update RELEASE_PROCESS.rst
