### PR TITLE
math_flowable: remove unnecessary critical warining

### DIFF
--- a/rst2pdf/math_flowable.py
+++ b/rst2pdf/math_flowable.py
@@ -166,12 +166,10 @@ class Math(Flowable):
                 (int(width * scale), int((height + descent) * scale)),
                 (255, 255, 255, 0),
             )
-            log.critical(f"descent = {descent}")
             draw = ImageDraw.Draw(img)
             for font, fontsize, num, ox, oy in glyphs:
                 fontname = font.fname
                 image_font = ImageFont.truetype(fontname, int(fontsize * scale))
-                log.critical(f"chr(num) = {chr(num)}")
                 fc = to_rgb(self.color)
                 rgb_color = (int(fc[0] * 255), int(fc[1] * 255), int(fc[2] * 255))
                 draw.text(


### PR DESCRIPTION
A critical warning appears during the build of the documents for each char inside the math formula even if it correctly appears in the pdf since the math support is not yet complete in rst2pdf,. For this reason, the log.critical() lines that generate them are being remove from math_flowable.py.

Signed-off-by: Arianna Galzerano <ariannagalzerano@gmail.com>
Closes: #1080