### PR TITLE
Add config option to change default subtitle prefix

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2015,9 +2015,9 @@ To use it in your existing Sphinx project you need to do the following:
 
     # Name of the cover page template to use
     # pdf_cover_template = 'sphinxcover.tmpl'
-	
-	# Label to use as a prefix for the subtitle on the cover page
-	# subtitle_prefix = 'version'
+
+    # Label to use as a prefix for the subtitle on the cover page
+    # subtitle_prefix = 'version'
 
     # Documents to append as an appendix to all manuals.
     # pdf_appendices = []

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2015,6 +2015,9 @@ To use it in your existing Sphinx project you need to do the following:
 
     # Name of the cover page template to use
     # pdf_cover_template = 'sphinxcover.tmpl'
+	
+	# Label to use as a prefix for the subtitle on the cover page
+	# subtitle_prefix = 'version'
 
     # Documents to append as an appendix to all manuals.
     # pdf_appendices = []

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -680,7 +680,7 @@ class PDFWriter(writers.Writer):
             # Feed data to the template, get restructured text.
             cover_text = template.render(
                 title=self.document.settings.title or visitor.elements['title'],
-                subtitle='%s %s' % (_('version'), self.config.version),
+                subtitle='%s %s' % (self.config.subtitle_prefix, self.config.version),
                 authors=authors,
                 date=date,
             )
@@ -991,6 +991,7 @@ def setup(app):
     app.add_config_value(
         'pdf_baseurl', urlunparse(['file', os.getcwd() + os.sep, '', '', '', '']), None
     )
+    app.add_config_value('subtitle_prefix', "version", None)
 
     project_doc = app.config.project + ' Documentation'
     app.config.pdf_documents.append(

--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -991,7 +991,7 @@ def setup(app):
     app.add_config_value(
         'pdf_baseurl', urlunparse(['file', os.getcwd() + os.sep, '', '', '', '']), None
     )
-    app.add_config_value('subtitle_prefix', "version", None)
+    app.add_config_value('subtitle_prefix', 'version', None)
 
     project_doc = app.config.project + ' Documentation'
     app.config.pdf_documents.append(

--- a/tests/input/sphinx-subtitle-prefix/conf.py
+++ b/tests/input/sphinx-subtitle-prefix/conf.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+
+# -- General configuration -----------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = ['rst2pdf.pdfbuilder']
+
+# The master toctree document.
+master_doc = 'index'
+
+# General information about the project.
+project = u'sphinxsubtitle'
+copyright = u'2023, rst2pdf project'
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = '1.1'
+# The full version, including alpha/beta/rc tags.
+release = '1.0-test-release'
+
+
+# -- Options for PDF output --------------------------------------------------
+
+# Grouping the document tree into PDF files. List of tuples
+# (source start file, target name, title, author, options).
+#
+# If there is more than one author, separate them with \\.
+# For example: r'Guido van Rossum\\Fred L. Drake, Jr., editor'
+#
+# The options element is a dictionary that lets you override
+# this config per-document. For example:
+#
+# ('index', 'MyProject', 'My Project', 'Author Name', {'pdf_compressed': True})
+#
+# would mean that specific document would be compressed
+# regardless of the global 'pdf_compressed' setting.
+
+pdf_documents = [
+    ('index', 'MyProject', 'My Project', 'Author Name'),
+]
+
+# A comma-separated list of custom stylesheets. Example:
+pdf_stylesheets = ['sphinx', 'a4']
+
+# A list of folders to search for stylesheets. Example:
+#pdf_style_path = ['.', '_styles']
+
+# Create a compressed PDF
+# Use True/False or 1/0
+# Example: compressed=True
+# pdf_compressed = False
+
+# A colon-separated list of folders to search for fonts. Example:
+# pdf_font_path = ['/usr/share/fonts', '/usr/share/texmf-dist/fonts/']
+
+# Language to be used for hyphenation support
+# pdf_language = "en_US"
+
+# Mode for literal blocks wider than the frame. Can be
+# overflow, shrink or truncate
+# pdf_fit_mode = "shrink"
+
+# Section level that forces a break page.
+# For example: 1 means top-level sections start in a new page
+# 0 means disabled
+# pdf_break_level = 0
+
+# When a section starts in a new page, force it to be 'even', 'odd',
+# or just use 'any'
+# pdf_breakside = 'any'
+
+# Insert footnotes where they are defined instead of
+# at the end.
+# pdf_inline_footnotes = True
+
+# verbosity level. 0 1 or 2
+# pdf_verbosity = 0
+
+# If false, no index is generated.
+# pdf_use_index = True
+
+# If false, no modindex is generated.
+# pdf_use_modindex = True
+
+# If false, no coverpage is generated.
+# pdf_use_coverpage = True
+
+# Name of the cover page template to use
+# pdf_cover_template = 'sphinxcover.tmpl'
+
+# Label to use as a prefix for the subtitle on the cover page
+subtitle_prefix = 'Subtle Subtitle Prefix'
+
+# Documents to append as an appendix to all manuals.
+# pdf_appendices = []
+
+# Enable experimental feature to split table cells. Use it
+# if you get "DelayedTable too big" errors
+# pdf_splittables = False
+
+# Set the default DPI for images
+# pdf_default_dpi = 72
+
+# Enable rst2pdf extension modules
+# pdf_extensions = []
+
+# Page template name for "regular" pages
+# pdf_page_template = 'cutePage'
+
+# Show Table Of Contents at the beginning?
+# pdf_use_toc = True
+
+# How many levels deep should the table of contents be?
+pdf_toc_depth = 9999
+
+# Add section number to section references
+pdf_use_numbered_links = False
+
+# Background images fitting mode
+pdf_fit_background_mode = 'scale'
+
+# Repeat table header on tables that cross a page boundary?
+pdf_repeat_table_rows = True
+
+# Enable smart quotes (1, 2 or 3) or disable by setting to 0
+pdf_smartquotes = 0

--- a/tests/input/sphinx-subtitle-prefix/index.rst
+++ b/tests/input/sphinx-subtitle-prefix/index.rst
@@ -1,0 +1,4 @@
+Sphinx subtitle prefix test
+###########################
+
+This document exists to test subtitles on the cover page.

--- a/tests/reference/sphinx-subtitle-prefix.pdf
+++ b/tests/reference/sphinx-subtitle-prefix.pdf
@@ -1,0 +1,351 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 10 0 R /XYZ 40.01575 787.0394 0 ] /Rect [ 40.01575 755.8394 143.9282 766.0394 ] /Subtype /Link /Type /Annot
+>>
+endobj
+7 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 10 0 R /XYZ 40.01575 787.0394 0 ] /Rect [ 550.5338 756.4769 555.2598 766.6769 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/Annots [ 6 0 R 7 0 R ] /Contents 18 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Outlines 13 0 R /PageLabels 21 0 R /PageMode /UseNone /Pages 15 0 R /Type /Catalog
+>>
+endobj
+12 0 obj
+<<
+/Author () /CreationDate (D:20230820212442+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20230820212442+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title () /Trapped /False
+>>
+endobj
+13 0 obj
+<<
+/Count 1 /First 14 0 R /Last 14 0 R /Type /Outlines
+>>
+endobj
+14 0 obj
+<<
+/Dest [ 10 0 R /XYZ 40.01575 787.0394 0 ] /Parent 13 0 R /Title (Sphinx subtitle prefix test)
+>>
+endobj
+15 0 obj
+<<
+/Count 5 /Kids [ 4 0 R 5 0 R 8 0 R 9 0 R 10 0 R ] /Type /Pages
+>>
+endobj
+16 0 obj
+<<
+/Length 888
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+.12549 .262745 .360784 rg
+BT 1 0 0 1 0 4 Tm /F2 20 Tf 24 TL 207.052 0 Td (My Project) Tj T* -207.052 0 Td ET
+Q
+Q
+q
+1 0 0 1 40.01575 721.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 24 re B*
+Q
+q
+.12549 .262745 .360784 rg
+BT 1 0 0 1 0 3 Tm /F2 15 Tf 18 TL 169.677 0 Td (Subtle Subtitle Prefix 1.1) Tj T* -169.677 0 Td ET
+Q
+Q
+q
+1 0 0 1 40.01575 600 cm
+Q
+q
+1 0 0 1 40.01575 579.6 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2.4 Tm /F2 12 Tf 14.4 TL 219.954 0 Td (Author Name) Tj T* -219.954 0 Td ET
+Q
+Q
+q
+1 0 0 1 40.01575 494.5606 cm
+Q
+q
+1 0 0 1 40.01575 474.1606 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2.4 Tm /F1 12 Tf 14.4 TL 213.924 0 Td (August 20, 2023) Tj T* -213.924 0 Td ET
+Q
+Q
+q
+1 0 0 1 40.01575 474.1606 cm
+Q
+q
+1 0 0 1 40.01575 474.1606 cm
+Q
+ 
+endstream
+endobj
+17 0 obj
+<<
+/Length 75
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 799.0394 cm
+Q
+ 
+endstream
+endobj
+18 0 obj
+<<
+/Length 598
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 775.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (Contents) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 752.8394 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 0 3 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F2 8.5 Tf 0 .4 .6 rg (Sphinx subtitle prefix test) Tj T* ET
+Q
+Q
+q
+1 0 0 1 443.2441 3 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F2 8.5 Tf 10.2 TL 67.274 0 Td (1) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 40.01575 752.8394 cm
+Q
+q
+1 0 0 1 40.01575 752.8394 cm
+Q
+ 
+endstream
+endobj
+19 0 obj
+<<
+/Length 75
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 799.0394 cm
+Q
+ 
+endstream
+endobj
+20 0 obj
+<<
+/Length 610
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 40.01575 763.0394 cm
+q
+.8 .8 .8 RG
+.3 w
+.94902 .94902 .94902 rg
+n -10 0 525.2441 30 re B*
+Q
+q
+BT 1 0 0 1 0 4 Tm 24 TL /F2 20 Tf .12549 .262745 .360784 rg (Sphinx subtitle prefix test) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 745.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This document exists to test subtitles on the cover page.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 34.01575 807.2126 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Sphinx subtitle prefix test) Tj T* ET
+Q
+Q
+q
+1 0 0 1 34.01575 22.67717 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (1) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+21 0 obj
+<<
+/Nums [ 0 22 0 R 1 23 0 R 2 24 0 R 3 25 0 R 4 26 0 R ]
+>>
+endobj
+22 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+23 0 obj
+<<
+/S /D /St 2
+>>
+endobj
+24 0 obj
+<<
+/S /r /St 1
+>>
+endobj
+25 0 obj
+<<
+/S /r /St 2
+>>
+endobj
+26 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+xref
+0 27
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000538 00000 n 
+0000000743 00000 n 
+0000000911 00000 n 
+0000001079 00000 n 
+0000001308 00000 n 
+0000001513 00000 n 
+0000001719 00000 n 
+0000001825 00000 n 
+0000002083 00000 n 
+0000002157 00000 n 
+0000002273 00000 n 
+0000002358 00000 n 
+0000003297 00000 n 
+0000003422 00000 n 
+0000004071 00000 n 
+0000004196 00000 n 
+0000004857 00000 n 
+0000004934 00000 n 
+0000004968 00000 n 
+0000005002 00000 n 
+0000005036 00000 n 
+0000005070 00000 n 
+trailer
+<<
+/ID 
+[<8fd540f5be961cb34587f6a6079a6650><8fd540f5be961cb34587f6a6079a6650>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 12 0 R
+/Root 11 0 R
+/Size 27
+>>
+startxref
+5104
+%%EOF


### PR DESCRIPTION
I think that the end user should have the option to change the default subtitle prefix. For example, from "version" to "release" or "v.". It would also allow the end user to set the prefix to a empty string to remove it completely when not needed. 