### PR TITLE
Write dependency file

### DIFF
--- a/doc/rst2pdf.rst
+++ b/doc/rst2pdf.rst
@@ -170,6 +170,9 @@ The possible values are:
                       Remove elements with this CLASS from the output. Can
                       be used multiple times.
 
+--record-dependencies=FILE
+                      Write output file dependencies to FILE.
+
 
 EXAMPLES
 --------

--- a/rst2pdf/styles.py
+++ b/rst2pdf/styles.py
@@ -67,7 +67,14 @@ class StyleSheet(object):
                 name = names.pop()
                 yield name, styles[name]
 
-    def __init__(self, flist, font_path=None, style_path=None, def_dpi=300):
+    def __init__(
+        self,
+        flist,
+        font_path=None,
+        style_path=None,
+        def_dpi=300,
+        record_dependencies=None,
+    ):
         log.info('Using stylesheets: %s' % ','.join(flist))
 
         self.suppress_undefined_style_warning = False
@@ -139,6 +146,7 @@ class StyleSheet(object):
         self.emsize = 10
 
         self.languages = []
+        self.record_dependencies = record_dependencies
 
         ssdata = self.readSheets(flist)
 
@@ -261,6 +269,8 @@ class StyleSheet(object):
                             # strip extension and leading path to get the name
                             # to register the font under
                             filename = os.path.basename(variant)
+                            if self.record_dependencies:
+                                self.record_dependencies.add(filename)
                             fontname = str(filename.split('.')[0])
                             pdfmetrics.registerFont(TTFont(fontname, location))
                             log.info(
@@ -596,6 +606,9 @@ class StyleSheet(object):
 
         fname = self.findStyle(ssname)
         if fname:
+            if self.record_dependencies:
+                self.record_dependencies.add(fname)
+
             try:
                 # TODO no longer needed when we drop support for rson
                 # Is it an older rson/json stylesheet with .style extension?

--- a/rst2pdf/utils.py
+++ b/rst2pdf/utils.py
@@ -3,6 +3,7 @@
 
 import shlex
 
+import jinja2
 from reportlab.lib.colors import Color
 from reportlab.platypus.flowables import CondPageBreak
 
@@ -396,3 +397,14 @@ else:  # no xhtml2pdf
     def parseHTML(data, none):
         log.error("You need xhtml2pdf installed to use the raw HTML directive.")
         return []
+
+
+class DependencyRecordingFileSystemLoader(jinja2.FileSystemLoader):
+    def __init__(self, *args, record_dependencies=None, **kwargs):
+        self.record_dependencies = record_dependencies
+        super().__init__(*args, **kwargs)
+
+    def get_source(self, environment, template):
+        r = (_, path, _) = super().get_source(environment, template)
+        self.record_dependencies.add(path)
+        return r


### PR DESCRIPTION
> Duplicate PR to try to trigger the build on #1111 

Add new parameter --record-dependencies which works the same way was for vanilla docutils rst2foo commands.

The target file will contain a list of files that were used to generate the output file. The list can be consumed by build-systems to efficiently regenerate the PDF if any of the inputs has changed.

Fixes #1108