### PR TITLE
Only allow Python 3.11 builds to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,11 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10']
         experimental: [false]
+        include:
+          - python-version: '3.11'
+            experimental: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        experimental: [false, false, false, true]
+        experimental: [false]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
-        experimental: [true]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        experimental: [false, false, false, true]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We don't want to allow everything to `continue-on-error` as we don't spot when there's a real failure.

We let 3.11 fail as ReportLab 3.6.3 doesn't install on 3.11 and we need move to a more recent ReportLab for that one (#1110).