### PR TITLE
Set language to "en" when running tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,7 +303,7 @@ class RstItem(Item):
                 else:
                     os.remove(path)
 
-        cmd = ['rst2pdf', '--date-invariant', '-v', input_ref]
+        cmd = ['rst2pdf', '--lang', 'en', '--date-invariant', '-v', input_ref]
 
         cli_file = os.path.join(INPUT_DIR, self.name + '.cli')
         if os.path.exists(cli_file):


### PR DESCRIPTION
If a user has another language configured in ~/.rst2pdf/config, for example "language=de", some of the tests will fail. By setting "en" explicity, the same tests will pass.

The following tests fail with language="de" in the config file:

```
FAILED tests/input/test_custom_cover.rst::test_custom_cover
FAILED tests/input/test_issue_128.rst::test_issue_128
FAILED tests/input/test_issue_117.rst::test_issue_117
FAILED tests/input/test_cover.rst::test_cover
FAILED tests/input/test_cover_2.rst::test_cover_2
FAILED tests/input/test_issue_109.rst::test_issue_109
FAILED tests/input/test_issue_299.rst::test_issue_299
FAILED tests/input/test_issue_165.rst::test_issue_165
FAILED tests/input/test_issue_288.rst::test_issue_288
FAILED tests/input/test_issue_64_handle_multiple_authors_in_metadata.rst::test_issue_64_handle_multiple_authors_in_metadata
FAILED tests/input/test_issue_64_handle_author_and_email_addresses_in_metadata.rst::test_issue_64_handle_author_and_email_addresses_in_metadata
FAILED tests/input/test_issue_351.rst::test_issue_351
FAILED tests/input/test_sidebar_literal2.rst::test_sidebar_literal2
FAILED tests/input/test_split_notes.rst::test_split_notes
```
