### PR TITLE
Restore twocolumn.yaml

### DIFF
--- a/rst2pdf/styles/twocolumn.yaml
+++ b/rst2pdf/styles/twocolumn.yaml
@@ -1,0 +1,4 @@
+pageSetup:
+  firstTemplate: twoColumn
+  margin-left: 1cm
+  margin-right: 1cm

--- a/tests/reference/test_stylesheet_includes.pdf
+++ b/tests/reference/test_stylesheet_includes.pdf
@@ -38,43 +38,50 @@ endobj
 endobj
 7 0 obj
 <<
-/Length 5076
+/Length 6169
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
 q
-1 0 0 1 57.02362 669.0236 cm
+1 0 0 1 34.34646 573.0236 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 84 Tm /F1 12 Tf 12 TL 3.145362 Tw (Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus pulvinar dui in felis) Tj T* 0 Tw .750362 Tw (convallis tempus. Phasellus neque neque, ornare eget cursus in, egestas a turpis. Lorem) Tj T* 0 Tw 2.643362 Tw (ipsum dolor sit amet, consectetur adipiscing elit. Class aptent taciti sociosqu ad litora) Tj T* 0 Tw 3.48585 Tw (torquent per conubia nostra, per inceptos himenaeos. Fusce blandit metus vitae dui) Tj T* 0 Tw .180334 Tw (interdum dictum. Quisque sed odio urna. Class aptent taciti sociosqu ad litora torquent per) Tj T* 0 Tw .302835 Tw (conubia nostra, per inceptos himenaeos. Vestibulum ultricies orci consectetur leo tincidunt) Tj T* 0 Tw 3.305362 Tw (feugiat. Praesent ut dolor tortor, eget tincidunt leo. Integer luctus, risus quis congue) Tj T* 0 Tw (bibendum, nibh ligula tempus eros, a hendrerit justo erat eget eros.) Tj T* ET
+BT 1 0 0 1 0 180 Tm /F1 12 Tf 12 TL 7.699502 Tw (Lorem ipsum dolor sit amet, consectetur) Tj T* 0 Tw 4.194252 Tw (adipiscing elit. Vivamus pulvinar dui in felis) Tj T* 0 Tw 6.948378 Tw (convallis tempus. Phasellus neque neque,) Tj T* 0 Tw 1.018502 Tw (ornare eget cursus in, egestas a turpis. Lorem) Tj T* 0 Tw 3.830702 Tw (ipsum dolor sit amet, consectetur adipiscing) Tj T* 0 Tw 6.414252 Tw (elit. Class aptent taciti sociosqu ad litora) Tj T* 0 Tw 6.624302 Tw (torquent per conubia nostra, per inceptos) Tj T* 0 Tw 6.228302 Tw (himenaeos. Fusce blandit metus vitae dui) Tj T* 0 Tw .412252 Tw (interdum dictum. Quisque sed odio urna. Class) Tj T* 0 Tw 4.298252 Tw (aptent taciti sociosqu ad litora torquent per) Tj T* 0 Tw 8.949378 Tw (conubia nostra, per inceptos himenaeos.) Tj T* 0 Tw 10.29338 Tw (Vestibulum ultricies orci consectetur leo) Tj T* 0 Tw 1.406252 Tw (tincidunt feugiat. Praesent ut dolor tortor, eget) Tj T* 0 Tw 1.520252 Tw (tincidunt leo. Integer luctus, risus quis congue) Tj T* 0 Tw .854252 Tw (bibendum, nibh ligula tempus eros, a hendrerit) Tj T* 0 Tw (justo erat eget eros.) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 579.0236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 72 Tm /F1 12 Tf 12 TL .753362 Tw (Vestibulum nec nisi dui, eget sollicitudin leo. Praesent turpis tellus, molestie non molestie) Tj T* 0 Tw 1.598025 Tw (non, consectetur non enim. Proin non nisl sit amet lorem rutrum adipiscing vitae ut est.) Tj T* 0 Tw .033362 Tw (Nullam commodo posuere tellus, nec convallis risus malesuada sit amet. Praesent a lorem) Tj T* 0 Tw .747104 Tw (sit amet mi tincidunt egestas nec et metus. Vivamus sodales bibendum ipsum vel lacinia.) Tj T* 0 Tw 1.566796 Tw (Morbi rhoncus feugiat odio, sed sodales massa pellentesque ut. Nam ac nisl sed lorem) Tj T* 0 Tw 2.419362 Tw (lacinia tempor sodales at turpis. Duis nec consectetur libero. Proin porttitor, ante eget) Tj T* 0 Tw (malesuada semper, nisl magna vestibulum orci, nec commodo turpis lectus vel libero.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 465.0236 cm
+1 0 0 1 34.34646 399.0236 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 96 Tm /F1 12 Tf 12 TL 2.883668 Tw (Quisque sem turpis, malesuada sed rhoncus vitae, lobortis sit amet arcu. Vestibulum) Tj T* 0 Tw 2.531362 Tw (ornare malesuada tortor. Donec sit amet orci non purus dignissim faucibus. Sed urna) Tj T* 0 Tw 2.588362 Tw (enim, interdum id egestas in, auctor tincidunt felis. Nullam quam tortor, elementum in) Tj T* 0 Tw 1.473362 Tw (tincidunt non, adipiscing sit amet eros. Etiam posuere posuere quam, eget tincidunt nisl) Tj T* 0 Tw .503235 Tw (vestibulum in. Donec tincidunt consequat nisi, et adipiscing purus scelerisque elementum.) Tj T* 0 Tw .638835 Tw (Maecenas elementum tempor ultricies. Phasellus vitae interdum neque. Nam nunc lorem,) Tj T* 0 Tw .641873 Tw (semper at tristique vel, commodo non ante. Duis placerat dui sed augue volutpat lobortis.) Tj T* 0 Tw .981739 Tw (Maecenas ac tempor lorem. Nam at nisl felis, a adipiscing dui. Mauris quis tempor enim.) Tj T* 0 Tw (Integer est dui, egestas non ullamcorper eu, hendrerit adipiscing urna.) Tj T* ET
+BT 1 0 0 1 0 156 Tm /F1 12 Tf 12 TL 2.968252 Tw (Vestibulum nec nisi dui, eget sollicitudin leo.) Tj T* 0 Tw 3.429902 Tw (Praesent turpis tellus, molestie non molestie) Tj T* 0 Tw 2.256216 Tw (non, consectetur non enim. Proin non nisl sit) Tj T* 0 Tw 5.416252 Tw (amet lorem rutrum adipiscing vitae ut est.) Tj T* 0 Tw 1.032302 Tw (Nullam commodo posuere tellus, nec convallis) Tj T* 0 Tw .831645 Tw (risus malesuada sit amet. Praesent a lorem sit) Tj T* 0 Tw 6.746252 Tw (amet mi tincidunt egestas nec et metus.) Tj T* 0 Tw 2.097902 Tw (Vivamus sodales bibendum ipsum vel lacinia.) Tj T* 0 Tw .188252 Tw (Morbi rhoncus feugiat odio, sed sodales massa) Tj T* 0 Tw 1.116216 Tw (pellentesque ut. Nam ac nisl sed lorem lacinia) Tj T* 0 Tw .856252 Tw (tempor sodales at turpis. Duis nec consectetur) Tj T* 0 Tw 5.025902 Tw (libero. Proin porttitor, ante eget malesuada) Tj T* 0 Tw 7.567502 Tw (semper, nisl magna vestibulum orci, nec) Tj T* 0 Tw (commodo turpis lectus vel libero.) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 327.0236 cm
-q
-0 0 0 rg
-BT 1 0 0 1 0 120 Tm /F1 12 Tf 12 TL 2.237873 Tw (Nullam id enim elit, ac mollis libero. Praesent felis enim, vulputate sit amet sollicitudin) Tj T* 0 Tw 4.036759 Tw (vitae, lacinia id justo. Curabitur volutpat, erat vel elementum vestibulum, sem enim) Tj T* 0 Tw .866362 Tw (consectetur diam, in tempor massa turpis eu est. Fusce ornare vestibulum tristique. Cras) Tj T* 0 Tw 2.644596 Tw (eu nisi vitae augue tincidunt aliquam. Proin eu augue est. In et ipsum dignissim velit) Tj T* 0 Tw .133257 Tw (molestie gravida. Phasellus nec odio at massa facilisis accumsan in sit amet lorem. Donec) Tj T* 0 Tw .637635 Tw (vestibulum sodales sapien, vitae malesuada enim auctor a. Mauris placerat condimentum) Tj T* 0 Tw 1.87418 Tw (neque aliquet sollicitudin. Nulla sit amet risus et ante auctor molestie. Donec et blandit) Tj T* 0 Tw .232027 Tw (velit. Nunc congue orci in augue volutpat eu gravida est commodo. Fusce gravida tristique) Tj T* 0 Tw 3.604759 Tw (est ut vulputate. Integer vulputate feugiat posuere. Vestibulum egestas lacinia est a) Tj T* 0 Tw 3.974577 Tw (sollicitudin. In gravida aliquam sapien, et hendrerit metus sollicitudin nec. Etiam eu) Tj T* 0 Tw (fermentum dui.) Tj T* ET
-Q
-Q
-q
-1 0 0 1 57.02362 225.0236 cm
+1 0 0 1 34.34646 177.0236 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 84 Tm /F1 12 Tf 12 TL 2.342577 Tw (Nulla nec enim ullamcorper odio ultricies dignissim. Pellentesque in mauris quis lorem) Tj T* 0 Tw 2.519304 Tw (lobortis fermentum rhoncus at odio. Suspendisse cursus aliquam tortor, et lobortis leo) Tj T* 0 Tw 2.031362 Tw (commodo in. Sed vitae vulputate ligula. Praesent vitae urna id ipsum tristique ultricies.) Tj T* 0 Tw .358596 Tw (Curabitur odio nisi, gravida quis venenatis nec, fermentum at metus. Ut eu neque sit amet) Tj T* 0 Tw .594796 Tw (nisl feugiat scelerisque eu vel enim. Curabitur felis ipsum, ultrices nec mattis eu, euismod) Tj T* 0 Tw 3.260642 Tw (et justo. Sed feugiat mauris sed arcu molestie et pretium arcu vestibulum. Fusce id) Tj T* 0 Tw 2.400395 Tw (imperdiet lorem. Aenean sem dolor, ullamcorper in scelerisque sed, fringilla in sapien.) Tj T* 0 Tw (Proin commodo blandit augue sit amet interdum.) Tj T* ET
+BT 1 0 0 1 0 204 Tm /F1 12 Tf 12 TL 2.894702 Tw (Quisque sem turpis, malesuada sed rhoncus) Tj T* 0 Tw .858252 Tw (vitae, lobortis sit amet arcu. Vestibulum ornare) Tj T* 0 Tw 4.858252 Tw (malesuada tortor. Donec sit amet orci non) Tj T* 0 Tw 6.497102 Tw (purus dignissim faucibus. Sed urna enim,) Tj T* 0 Tw 3.078252 Tw (interdum id egestas in, auctor tincidunt felis.) Tj T* 0 Tw 4.632302 Tw (Nullam quam tortor, elementum in tincidunt) Tj T* 0 Tw 2.634252 Tw (non, adipiscing sit amet eros. Etiam posuere) Tj T* 0 Tw -0.145748 Tw (posuere quam, eget tincidunt nisl vestibulum in.) Tj T* 0 Tw 3.158702 Tw (Donec tincidunt consequat nisi, et adipiscing) Tj T* 0 Tw 11.0525 Tw (purus scelerisque elementum. Maecenas) Tj T* 0 Tw 5.124378 Tw (elementum tempor ultricies. Phasellus vitae) Tj T* 0 Tw 2.302252 Tw (interdum neque. Nam nunc lorem, semper at) Tj T* 0 Tw .856252 Tw (tristique vel, commodo non ante. Duis placerat) Tj T* 0 Tw 1.852252 Tw (dui sed augue volutpat lobortis. Maecenas ac) Tj T* 0 Tw 2.83393 Tw (tempor lorem. Nam at nisl felis, a adipiscing) Tj T* 0 Tw 1.687073 Tw (dui. Mauris quis tempor enim. Integer est dui,) Tj T* 0 Tw 12.45338 Tw (egestas non ullamcorper eu, hendrerit) Tj T* 0 Tw (adipiscing urna.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 34.34646 63.02362 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 96 Tm /F1 12 Tf 12 TL 1.882502 Tw (Nullam id enim elit, ac mollis libero. Praesent) Tj T* 0 Tw 1.636252 Tw (felis enim, vulputate sit amet sollicitudin vitae,) Tj T* 0 Tw 4.858252 Tw (lacinia id justo. Curabitur volutpat, erat vel) Tj T* 0 Tw 1.956378 Tw (elementum vestibulum, sem enim consectetur) Tj T* 0 Tw 3.212787 Tw (diam, in tempor massa turpis eu est. Fusce) Tj T* 0 Tw 2.082252 Tw (ornare vestibulum tristique. Cras eu nisi vitae) Tj T* 0 Tw .156216 Tw (augue tincidunt aliquam. Proin eu augue est. In) Tj T* 0 Tw 6.902702 Tw (et ipsum dignissim velit molestie gravida.) Tj T* 0 Tw -0.141748 Tw (Phasellus nec odio at massa facilisis accumsan) Tj T* 0 Tw ET
+Q
+Q
+q
+1 0 0 1 309.0236 633.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 120 Tm /F1 12 Tf 12 TL 2.860252 Tw (in sit amet lorem. Donec vestibulum sodales) Tj T* 0 Tw .634252 Tw (sapien, vitae malesuada enim auctor a. Mauris) Tj T* 0 Tw 19.4925 Tw (placerat condimentum neque aliquet) Tj T* 0 Tw 1.688787 Tw (sollicitudin. Nulla sit amet risus et ante auctor) Tj T* 0 Tw 1.966252 Tw (molestie. Donec et blandit velit. Nunc congue) Tj T* 0 Tw -0.030641 Tw (orci in augue volutpat eu gravida est commodo.) Tj T* 0 Tw .408252 Tw (Fusce gravida tristique est ut vulputate. Integer) Tj T* 0 Tw 1.443378 Tw (vulputate feugiat posuere. Vestibulum egestas) Tj T* 0 Tw 4.192252 Tw (lacinia est a sollicitudin. In gravida aliquam) Tj T* 0 Tw 5.695502 Tw (sapien, et hendrerit metus sollicitudin nec.) Tj T* 0 Tw (Etiam eu fermentum dui.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 309.0236 447.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 168 Tm /F1 12 Tf 12 TL 7.303502 Tw (Nulla nec enim ullamcorper odio ultricies) Tj T* 0 Tw 3.033902 Tw (dignissim. Pellentesque in mauris quis lorem) Tj T* 0 Tw 15.95738 Tw (lobortis fermentum rhoncus at odio.) Tj T* 0 Tw 1.829102 Tw (Suspendisse cursus aliquam tortor, et lobortis) Tj T* 0 Tw 3.966252 Tw (leo commodo in. Sed vitae vulputate ligula.) Tj T* 0 Tw 1.192252 Tw (Praesent vitae urna id ipsum tristique ultricies.) Tj T* 0 Tw .522252 Tw (Curabitur odio nisi, gravida quis venenatis nec,) Tj T* 0 Tw .808689 Tw (fermentum at metus. Ut eu neque sit amet nisl) Tj T* 0 Tw 1.080252 Tw (feugiat scelerisque eu vel enim. Curabitur felis) Tj T* 0 Tw .449359 Tw (ipsum, ultrices nec mattis eu, euismod et justo.) Tj T* 0 Tw 6.858252 Tw (Sed feugiat mauris sed arcu molestie et) Tj T* 0 Tw 3.967502 Tw (pretium arcu vestibulum. Fusce id imperdiet) Tj T* 0 Tw 7.166702 Tw (lorem. Aenean sem dolor, ullamcorper in) Tj T* 0 Tw 7.565102 Tw (scelerisque sed, fringilla in sapien. Proin) Tj T* 0 Tw (commodo blandit augue sit amet interdum.) Tj T* ET
 Q
 Q
  
@@ -100,8 +107,8 @@ xref
 0000000500 00000 n 
 0000000757 00000 n 
 0000000816 00000 n 
-0000005943 00000 n 
-0000005982 00000 n 
+0000007036 00000 n 
+0000007075 00000 n 
 trailer
 <<
 /ID 
@@ -113,5 +120,5 @@ trailer
 /Size 10
 >>
 startxref
-6015
+7108
 %%EOF


### PR DESCRIPTION
This file is required as a way to set the two column layout via a stylesheet. It was incorrectly removed in #1126.

Fixes #1159
