### PR TITLE
Make the hl_lines directive work with plain text

### DIFF
--- a/rst2pdf/basenodehandler.py
+++ b/rst2pdf/basenodehandler.py
@@ -236,7 +236,7 @@ class NodeHandler(metaclass=MetaHelper):
                     else:
                         log.info(
                             "Unknown class %s, ignoring. [%s]",
-                            n,
+                            node['classes'][n],
                             nodeid(node),
                         )
         except TypeError:  # Happens when a docutils.node.Text reaches here

--- a/rst2pdf/directives/code_block.py
+++ b/rst2pdf/directives/code_block.py
@@ -272,23 +272,28 @@ def code_block_directive(
         if hl_lines and lineno not in hl_lines:
             cls = "diml"
         if withln and "\n" in value:
-            linenumber_cls = 'linenumber'
-            if (
-                hl_lines and (lineno + 1) not in hl_lines
-            ):  # use lineno+1 as we're on the previous line when we render the next line number
-                linenumber_cls = 'pygments-diml'
             # Split on the "\n"s
             values = value.split("\n")
             # The first piece, pass as-is
-            code_block += nodes.Text(values[0], values[0])
+            c = ''
+            if cls != '':
+                c = 'pygments-diml'
+            code_block += nodes.inline(values[0], values[0], classes=[c])
+
             # On the second and later pieces, insert \n and linenos
             linenos = range(lineno, lineno + len(values))
             for chunk, ln in list(zip(values, linenos))[1:]:
                 if ln <= total_lines:
+                    linenumber_cls = 'linenumber'
+                    c = ''
+                    if hl_lines and (ln) not in hl_lines:
+                        linenumber_cls = 'pygments-diml'
+                        c = 'pygments-diml'
+
                     code_block += nodes.inline(
                         fstr % ln, fstr % ln, classes=[linenumber_cls]
                     )
-                    code_block += nodes.Text(chunk, chunk)
+                    code_block += nodes.inline(chunk, chunk, classes=[c])
             lineno += len(values) - 1
 
         elif cls in unstyled_tokens:

--- a/tests/input/test_hl_lines.rst
+++ b/tests/input/test_hl_lines.rst
@@ -1,20 +1,33 @@
 Highlight lines
 ---------------
 
-The following code snippet should dim all lines that are not marked with
+The following code-blocks should dim all lines that are not marked with
 ``hl_lines``, and so the effect is to highlight the selected lines
+
+With this block of plain text, lines 1 and 3 are dimmed:
+
+.. code-block:: text
+   :linenos:
+   :hl_lines: 2
+
+   To be
+   or not to be
+   that is the question
+
+For this block of Python, lines 1, 2, 4, 6, 8, 9 and 10 are dimmed:
 
 .. code-block:: python
    :linenos:
-   :hl_lines: 3 5 6
+   :hl_lines: 3 5 7
 
-    def f():
-        a = 1
-        b = 2
-        c = 3
-        d = 4
-        e = 5
-        f = 6
-        g = 7
+   number = 0
 
+   if number > 0:
+       print("Positive number")
+   elif number == 0:
+       print('Zero')
+   else:
+       print('Negative number')
+
+   print('This statement is always executed')
 

--- a/tests/reference/test_hl_lines.pdf
+++ b/tests/reference/test_hl_lines.pdf
@@ -2,7 +2,7 @@
 %“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
 <<
-/F1 2 0 R /F2 3 0 R /F3 4 0 R
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
 >>
 endobj
 2 0 obj
@@ -22,7 +22,12 @@ endobj
 endobj
 5 0 obj
 <<
-/Contents 9 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 8 0 R /Resources <<
+/BaseFont /Courier-Bold /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 9 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -30,25 +35,25 @@ endobj
   /Type /Page
 >>
 endobj
-6 0 obj
+7 0 obj
 <<
-/PageLabels 10 0 R /PageMode /UseNone /Pages 8 0 R /Type /Catalog
+/PageLabels 11 0 R /PageMode /UseNone /Pages 9 0 R /Type /Catalog
 >>
 endobj
-7 0 obj
+8 0 obj
 <<
 /Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
   /Subject (\(unspecified\)) /Title (Highlight lines) /Trapped /False
 >>
 endobj
-8 0 obj
-<<
-/Count 1 /Kids [ 5 0 R ] /Type /Pages
->>
-endobj
 9 0 obj
 <<
-/Length 3450
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Length 4765
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -62,11 +67,18 @@ Q
 q
 1 0 0 1 57.02362 681.0236 cm
 q
-BT 1 0 0 1 0 14 Tm .744123 Tw 12 TL /F1 10 Tf 0 0 0 rg (The following code snippet should dim all lines that are not marked with ) Tj /F3 10 Tf (hl_lines) Tj /F1 10 Tf (, and so the effect is to) Tj T* 0 Tw (highlight the selected lines) Tj T* ET
+BT 1 0 0 1 0 14 Tm .971575 Tw 12 TL /F1 10 Tf 0 0 0 rg (The following code-blocks should dim all lines that are not marked with ) Tj /F3 10 Tf (hl_lines) Tj /F1 10 Tf (, and so the effect is to) Tj T* 0 Tw (highlight the selected lines) Tj T* ET
 Q
 Q
 q
-1 0 0 1 57.02362 563.8236 cm
+1 0 0 1 57.02362 663.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (With this block of plain text, lines 1 and 3 are dimmed:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 605.8236 cm
 q
 q
 1 0 0 1 0 0 cm
@@ -76,108 +88,161 @@ q
 .662745 .662745 .662745 RG
 .5 w
 .941176 .972549 1 rg
-n -6 -6 480.0283 108 re B*
+n -6 -6 480.0283 48 re B*
 Q
 q
 .941176 .972549 1 rg
-n 0 84 12 12 re f*
-.941176 .972549 1 rg
-n 12 84 6 12 re f*
-.941176 .972549 1 rg
-n 18 84 18 12 re f*
-.941176 .972549 1 rg
-n 36 84 6 12 re f*
-.941176 .972549 1 rg
-n 42 84 6 12 re f*
-.941176 .972549 1 rg
-n 48 84 18 12 re f*
-.941176 .972549 1 rg
-n 66 84 0 12 re f*
-.941176 .972549 1 rg
-n 0 72 12 12 re f*
-.941176 .972549 1 rg
-n 42 72 6 12 re f*
-.941176 .972549 1 rg
-n 48 72 6 12 re f*
-.941176 .972549 1 rg
-n 54 72 6 12 re f*
-.941176 .972549 1 rg
-n 60 72 6 12 re f*
-.941176 .972549 1 rg
-n 66 72 6 12 re f*
-.941176 .972549 1 rg
-n 72 72 0 12 re f*
-.941176 .972549 1 rg
-n 0 60 12 12 re f*
-.941176 .972549 1 rg
-n 42 60 6 12 re f*
-.941176 .972549 1 rg
-n 54 60 6 12 re f*
-.941176 .972549 1 rg
-n 66 60 6 12 re f*
-.941176 .972549 1 rg
-n 72 60 0 12 re f*
-.941176 .972549 1 rg
-n 0 48 12 12 re f*
-.941176 .972549 1 rg
-n 42 48 6 12 re f*
-.941176 .972549 1 rg
-n 48 48 6 12 re f*
-.941176 .972549 1 rg
-n 54 48 6 12 re f*
-.941176 .972549 1 rg
-n 60 48 6 12 re f*
-.941176 .972549 1 rg
-n 66 48 6 12 re f*
-.941176 .972549 1 rg
-n 72 48 0 12 re f*
-.941176 .972549 1 rg
-n 0 36 12 12 re f*
-.941176 .972549 1 rg
-n 42 36 6 12 re f*
-.941176 .972549 1 rg
-n 54 36 6 12 re f*
-.941176 .972549 1 rg
-n 66 36 6 12 re f*
-.941176 .972549 1 rg
-n 72 36 0 12 re f*
-.941176 .972549 1 rg
 n 0 24 12 12 re f*
 .941176 .972549 1 rg
-n 42 24 6 12 re f*
+n 12 24 30 12 re f*
 .941176 .972549 1 rg
-n 54 24 6 12 re f*
-.941176 .972549 1 rg
-n 66 24 6 12 re f*
-.941176 .972549 1 rg
-n 72 24 0 12 re f*
+n 42 24 0 12 re f*
 .941176 .972549 1 rg
 n 0 12 12 12 re f*
 .941176 .972549 1 rg
-n 42 12 6 12 re f*
-.941176 .972549 1 rg
-n 48 12 6 12 re f*
-.941176 .972549 1 rg
-n 54 12 6 12 re f*
-.941176 .972549 1 rg
-n 60 12 6 12 re f*
-.941176 .972549 1 rg
-n 66 12 6 12 re f*
-.941176 .972549 1 rg
-n 72 12 0 12 re f*
+n 84 12 0 12 re f*
 .941176 .972549 1 rg
 n 0 0 12 12 re f*
 .941176 .972549 1 rg
-n 42 0 6 12 re f*
+n 12 0 120 12 re f*
+BT 1 0 0 1 0 26 Tm 12 TL /F3 10 Tf .666667 .666667 .666667 rg (1 ) Tj (To be) Tj 0 0 0 rg  T* (2 ) Tj (or not to be) Tj .666667 .666667 .666667 rg  T* (3 ) Tj (that is the question) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 585.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (For this block of Python, lines 1, 2, 4, 6, 8, 9 and 10 are dimmed:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 444.6236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.941176 .972549 1 rg
+n -6 -6 480.0283 132 re B*
+Q
+q
+.941176 .972549 1 rg
+n 0 108 18 12 re f*
+.941176 .972549 1 rg
+n 18 108 36 12 re f*
+.941176 .972549 1 rg
+n 54 108 6 12 re f*
+.941176 .972549 1 rg
+n 60 108 6 12 re f*
+.941176 .972549 1 rg
+n 66 108 6 12 re f*
+.941176 .972549 1 rg
+n 72 108 6 12 re f*
+.941176 .972549 1 rg
+n 78 108 0 12 re f*
+.941176 .972549 1 rg
+n 0 96 18 12 re f*
+.941176 .972549 1 rg
+n 18 96 0 12 re f*
+.941176 .972549 1 rg
+n 0 84 18 12 re f*
+.941176 .972549 1 rg
+n 18 84 12 12 re f*
+.941176 .972549 1 rg
+n 36 84 36 12 re f*
+.941176 .972549 1 rg
+n 78 84 6 12 re f*
+.941176 .972549 1 rg
+n 90 84 6 12 re f*
+.941176 .972549 1 rg
+n 96 84 6 12 re f*
+.941176 .972549 1 rg
+n 102 84 0 12 re f*
+.941176 .972549 1 rg
+n 0 72 18 12 re f*
+.941176 .972549 1 rg
+n 18 72 24 12 re f*
+.941176 .972549 1 rg
+n 42 72 30 12 re f*
+.941176 .972549 1 rg
+n 72 72 6 12 re f*
+.941176 .972549 1 rg
+n 78 72 102 12 re f*
+.941176 .972549 1 rg
+n 180 72 6 12 re f*
+.941176 .972549 1 rg
+n 186 72 0 12 re f*
+.941176 .972549 1 rg
+n 0 60 18 12 re f*
+.941176 .972549 1 rg
+n 18 60 24 12 re f*
+.941176 .972549 1 rg
+n 48 60 36 12 re f*
+.941176 .972549 1 rg
+n 90 60 12 12 re f*
+.941176 .972549 1 rg
+n 108 60 6 12 re f*
+.941176 .972549 1 rg
+n 114 60 6 12 re f*
+.941176 .972549 1 rg
+n 120 60 0 12 re f*
+.941176 .972549 1 rg
+n 0 48 18 12 re f*
+.941176 .972549 1 rg
+n 18 48 24 12 re f*
+.941176 .972549 1 rg
+n 42 48 30 12 re f*
+.941176 .972549 1 rg
+n 72 48 6 12 re f*
+.941176 .972549 1 rg
+n 78 48 36 12 re f*
+.941176 .972549 1 rg
+n 114 48 6 12 re f*
+.941176 .972549 1 rg
+n 120 48 0 12 re f*
+.941176 .972549 1 rg
+n 0 36 18 12 re f*
+.941176 .972549 1 rg
+n 18 36 24 12 re f*
+.941176 .972549 1 rg
+n 42 36 6 12 re f*
+.941176 .972549 1 rg
+n 48 36 0 12 re f*
+.941176 .972549 1 rg
+n 0 24 18 12 re f*
+.941176 .972549 1 rg
+n 18 24 24 12 re f*
+.941176 .972549 1 rg
+n 42 24 30 12 re f*
+.941176 .972549 1 rg
+n 72 24 6 12 re f*
+.941176 .972549 1 rg
+n 78 24 102 12 re f*
+.941176 .972549 1 rg
+n 180 24 6 12 re f*
+.941176 .972549 1 rg
+n 186 24 0 12 re f*
+.941176 .972549 1 rg
+n 0 12 18 12 re f*
+.941176 .972549 1 rg
+n 18 12 0 12 re f*
+.941176 .972549 1 rg
+n 0 0 18 12 re f*
+.941176 .972549 1 rg
+n 18 0 30 12 re f*
 .941176 .972549 1 rg
 n 48 0 6 12 re f*
 .941176 .972549 1 rg
-n 54 0 6 12 re f*
+n 54 0 210 12 re f*
 .941176 .972549 1 rg
-n 60 0 6 12 re f*
-.941176 .972549 1 rg
-n 66 0 6 12 re f*
-BT 1 0 0 1 0 86 Tm 12 TL /F3 10 Tf .666667 .666667 .666667 rg (1 ) Tj ( ) Tj (def) Tj ( ) Tj (f) Tj (\(\):) Tj  T* (2 ) Tj 0 0 0 rg (     ) Tj .666667 .666667 .666667 rg (a) Tj ( ) Tj (=) Tj ( ) Tj (1) Tj 0 0 0 rg  T* (3 ) Tj (     ) Tj (b) Tj ( ) Tj .4 .4 .4 rg (=) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (2) Tj .666667 .666667 .666667 rg  T* (4 ) Tj 0 0 0 rg (     ) Tj .666667 .666667 .666667 rg (c) Tj ( ) Tj (=) Tj ( ) Tj (3) Tj 0 0 0 rg  T* (5 ) Tj (     ) Tj (d) Tj ( ) Tj .4 .4 .4 rg (=) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (4) Tj 0 0 0 rg  T* (6 ) Tj (     ) Tj (e) Tj ( ) Tj .4 .4 .4 rg (=) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (5) Tj .666667 .666667 .666667 rg  T* (7 ) Tj 0 0 0 rg (     ) Tj .666667 .666667 .666667 rg (f) Tj ( ) Tj (=) Tj ( ) Tj (6) Tj  T* (8 ) Tj 0 0 0 rg (     ) Tj .666667 .666667 .666667 rg (g) Tj ( ) Tj (=) Tj ( ) Tj (7) Tj T* ET
+n 264 0 6 12 re f*
+BT 1 0 0 1 0 110 Tm 12 TL /F3 10 Tf .666667 .666667 .666667 rg ( 1 ) Tj (number) Tj ( ) Tj (=) Tj ( ) Tj (0) Tj  T* ( 2 ) Tj 0 0 0 rg  T* ( 3 ) Tj /F4 10 Tf 0 .501961 0 rg (if) Tj /F3 10 Tf 0 0 0 rg ( ) Tj (number) Tj ( ) Tj .4 .4 .4 rg (>) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (0) Tj 0 0 0 rg (:) Tj .666667 .666667 .666667 rg  T* ( 4 ) Tj (    ) Tj (print) Tj (\() Tj ("Positive number") Tj (\)) Tj 0 0 0 rg  T* ( 5 ) Tj /F4 10 Tf 0 .501961 0 rg (elif) Tj /F3 10 Tf 0 0 0 rg ( ) Tj (number) Tj ( ) Tj .4 .4 .4 rg (==) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (0) Tj 0 0 0 rg (:) Tj .666667 .666667 .666667 rg  T* ( 6 ) Tj (    ) Tj (print) Tj (\() Tj ('Zero') Tj (\)) Tj 0 0 0 rg  T* ( 7 ) Tj /F4 10 Tf 0 .501961 0 rg (else) Tj /F3 10 Tf 0 0 0 rg (:) Tj .666667 .666667 .666667 rg  T* ( 8 ) Tj (    ) Tj (print) Tj (\() Tj ('Negative number') Tj (\)) Tj  T* ( 9 ) Tj  T* (10 ) Tj (print) Tj (\() Tj ('This statement is always executed') Tj (\)) Tj T* ET
 Q
 Q
 Q
@@ -186,40 +251,41 @@ Q
  
 endstream
 endobj
-10 0 obj
+11 0 obj
 <<
-/Nums [ 0 11 0 R ]
+/Nums [ 0 12 0 R ]
 >>
 endobj
-11 0 obj
+12 0 obj
 <<
 /S /D /St 1
 >>
 endobj
 xref
-0 12
+0 13
 0000000000 65535 f 
 0000000073 00000 n 
-0000000124 00000 n 
-0000000231 00000 n 
-0000000340 00000 n 
-0000000445 00000 n 
-0000000648 00000 n 
-0000000735 00000 n 
-0000001007 00000 n 
-0000001066 00000 n 
-0000004567 00000 n 
-0000004608 00000 n 
+0000000134 00000 n 
+0000000241 00000 n 
+0000000350 00000 n 
+0000000455 00000 n 
+0000000565 00000 n 
+0000000769 00000 n 
+0000000856 00000 n 
+0000001128 00000 n 
+0000001187 00000 n 
+0000006004 00000 n 
+0000006045 00000 n 
 trailer
 <<
 /ID 
 [<19b7a0fd1e8e4f96176fce9e6b5d3271><19b7a0fd1e8e4f96176fce9e6b5d3271>]
 % ReportLab generated PDF document -- digest (http://www.reportlab.com)
 
-/Info 7 0 R
-/Root 6 0 R
-/Size 12
+/Info 8 0 R
+/Root 7 0 R
+/Size 13
 >>
 startxref
-4642
+6079
 %%EOF


### PR DESCRIPTION
As plain text code blocks have a different path through the codeblock directive, we need to apply the hl_lines "`diml`" class in this section too in order for highlighting to work.

I've also improved the Python test to show that syntax highlighting works on the highlighted lines and updated an error message to show the name of a class rather than its index within the list of classes.

This is an example from the new test in this PR:

RST code:
```rst
.. code-block:: text
   :linenos:
   :hl_lines: 2

   To be
   or not to be
   that is the question
```

Before this PR, only the first line number is dimmed:
<img width="894" alt="image" src="https://github.com/rst2pdf/rst2pdf/assets/33135/ced84d8a-7def-4e34-8127-5b9dae98ab49">

After, it works as you'd reasonably expect:
<img width="885" alt="image" src="https://github.com/rst2pdf/rst2pdf/assets/33135/1c980209-1964-4e7f-8e56-94781f8a4058">
