### PR TITLE
Adjust to py 3.12

### DIFF
--- a/rst2pdf/config.py
+++ b/rst2pdf/config.py
@@ -28,7 +28,7 @@ class ConfigError(Exception):
         self.msg = msg
 
 
-conf = configparser.SafeConfigParser()
+conf = configparser.ConfigParser()
 
 
 def parseConfig(extracf=None):
@@ -36,7 +36,7 @@ def parseConfig(extracf=None):
     cflist = ["/etc/rst2pdf.conf", cfname]
     if extracf:
         cflist.append(extracf)
-    conf = configparser.SafeConfigParser()
+    conf = configparser.ConfigParser()
     conf.read(cflist)
 
 


### PR DESCRIPTION
Py 3.12 finally pulled the plug on the `SafeConfigParser` class which has been deprecated since py 3.2. Use `ConfigParser` as the recommended replacement.