### PR TITLE
update 'pillow' version to 10.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ packaging==23.1
     #   pytest
     #   rst2pdf (setup.py)
     #   sphinx
-pillow==10.0.0
+pillow==10.1.0
     # via
     #   matplotlib
     #   reportlab


### PR DESCRIPTION
pillow 10.0.0 and earlier versions are known to be vulnerable.(CVE-2023-4863). 
Please update to the latest version.
https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html#security