### PR TITLE
pdfbuilder: Add supported_image_types attribute

### DIFF
--- a/rst2pdf/pdfbuilder.py
+++ b/rst2pdf/pdfbuilder.py
@@ -54,6 +54,7 @@ else:
 class PDFBuilder(Builder):
     name = 'pdf'
     out_suffix = '.pdf'
+    supported_image_types = ['image/svg+xml', 'image/png', 'image/gif', 'image/jpeg']
 
     def init(self):
         self.docnames = []


### PR DESCRIPTION
According to the Sphinx documentation Builders should include an attribute `supported_image_types`, that lists which images types can be used by this builder.

https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder

Other plugins rely on this behavior.

By specifying the list of image types, we ensure that the API exposes the capabilities correclty (since rst2pdf has image support).