### PR TITLE
Update compare_pdf.sh

### DIFF
--- a/tests/compare_pdf.sh
+++ b/tests/compare_pdf.sh
@@ -2,20 +2,28 @@
 #
 # Given two PDF files in the command line, create a visual diff of them in
 # another PDF
+set -x
+if [ -z "$1" ] ; then
+  echo "Usage: $(basename "$0") <file1.pdf> <file2.pdf> [temp_directory='/tmp/comppdf-"'$$'"']"
+  exit 1
+fi
 
 f1=$1
 f2=$2
 flag=0
 
-tmpdir=/tmp/comppdf-$$
-mkdir $tmpdir
-convert -density 96x96 $f1 $tmpdir/page.png
-convert -density 96x96 $f2 $tmpdir/bpage.png
+tmpdir="${3:-/tmp/comppdf-$$}"
 
-pushd $tmpdir >/dev/null 2>&1
+mkdir -p "$tmpdir"
+rm -f "$tmpdir"/*
+
+convert -density 96x96 "$f1" "png24:$tmpdir/page.png"
+convert -density 96x96 "$f2" "png24:$tmpdir/bpage.png"
+
+pushd "$tmpdir" >/dev/null 2>&1
 
 for page in page*.png; do
-    result=$(compare -metric PSNR $page b$page diff$page 2>&1)
+    result=$(compare -metric PSNR "$page" b"$page" "diff$page" 2>&1)
     if [ "$result" = "inf" ]; then
         true
     else


### PR DESCRIPTION
Some minor tweaks to `compare_pdf.sh`:

* Add usage message if no parameters are provided.
* Add 3rd optional parameter to set temp directory and ensure that it is empty.
* Use png24 colour depth for the `convert` calls to avoid warning about RGB colour space permissions on greyscale PNGs.
* Quote all filenames.
