### PR TITLE
Fix sphinx subtitle prefix test and ensure CI fails on test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
         pre-commit run --all-files --show-diff-on-failure
       if: matrix.python-version == '3.8'
     - name: Test with pytest
-      continue-on-error: true
       run: |
         pytest -v
     - name: Archive test output

--- a/tests/input/sphinx-subtitle-prefix/conf.py
+++ b/tests/input/sphinx-subtitle-prefix/conf.py
@@ -128,3 +128,6 @@ pdf_repeat_table_rows = True
 
 # Enable smart quotes (1, 2 or 3) or disable by setting to 0
 pdf_smartquotes = 0
+
+# Set a consistent date for the cover page
+today = 'August 20, 2023'


### PR DESCRIPTION
The `sphinx-subtitle-prefix` test has been failing due to a date issue. This PR fixes it by setting the date to match the reference PDF.

However, this was not found earlier because the CI indicates that the workflow passed even though it didn't. This is due to `continue-on-error: true` that we thought we needed to make the artefact upload step work. However, we subsequently changed the artefact upload step to upload only on failure by adding `if: failure()`, which I believe achieves what we were trying to do with `continue-on-error: true`.  However, we didn't update the pytest step, so this PR removes the `continue-on-error: true` now so that a failure is recognised by the system.