### PR TITLE
Deal with PyMuPDF installed as fitz_old

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,13 @@ import shutil
 import subprocess
 import tempfile
 
-import fitz
 from packaging import version
 import pytest
+
+try:
+    import fitz
+except ImportError:
+    import fitz_old as fitz
 
 
 ROOT_DIR = os.path.realpath(os.path.dirname(__file__))


### PR DESCRIPTION
PyMuPDF might be available on a system as fitz_old, which is currently the case for Debian sid. Try to import it if import fitz fails.