### PR TITLE
Update the python versions we use in CI to include 3.12 and 3.13 (experimental)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
         include:
-          - python-version: '3.13'
+          - python-version: '3.13.0-rc.1'
             experimental: true
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
         include:
-          - python-version: '3.11'
+          - python-version: '3.13'
             experimental: true
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         pytest -v
     - name: Archive test output
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: failed-tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ babel==2.15.0
     # via sphinx
 certifi==2024.2.2
     # via requests
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
 chardet==5.2.0
     # via reportlab

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ packaging==24.0
     #   pytest
     #   rst2pdf (setup.py)
     #   sphinx
-pillow==10.3.0
+pillow==10.4.0
     # via
     #   matplotlib
     #   reportlab

--- a/rst2pdf/findfonts.py
+++ b/rst2pdf/findfonts.py
@@ -320,7 +320,7 @@ def autoEmbed(fname):
         if variants:
             vname = os.path.basename(variants[0])[:-4]
             if vname != fname:
-                log.warn(
+                log.warning(
                     "Could not find font '%s'. Substituting with %s." % (fname, vname)
                 )
     # It is a TT Font and we found it using fc-match (or found *something*)


### PR DESCRIPTION
We're not testing against the newest versions of Python, this adds them to the CI build matrix so we can check what's what.