### PR TITLE
Fix sphinx test collection logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -432,7 +432,7 @@ def pytest_collect_file(file_path, parent):
 
     if file_path.suffix == '.rst' and parent_dir == 'input':
         return RstFile.from_parent(parent=parent, path=file_path)
-    elif file_path.stem == 'conf.py' and parent_dir.startswith('sphinx'):
+    elif file_path.name == 'conf.py' and parent_dir.startswith('sphinx'):
         return SphinxFile.from_parent(parent=parent, path=file_path)
 
 


### PR DESCRIPTION
While working on my second PR for #738, I noticed that the sample test command in `doc/DEVELOPERS.rst` no longer works:

> Running a single test
> *********************
> 
> To run one test only, simply pass the file or directory to pytest. For example::
> 
>   pytest tests/input/sphinx-repeat-table-rows

Local result:

```
 $  uv run pytest tests/input/sphinx-repeat-table-rows
================================ test session starts =================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/kyle/repos/rst2pdf
configfile: pyproject.toml
plugins: xdist-3.6.1
collected 0 items

=============================== no tests ran in 0.04s ================================
```

After some digging, I found it was because the custom test collection logic used `path.stem` (e.g. `conf`) instead of `path.name` (e.g. `conf.py`), but was expecting to compare it to `conf.py`.

Before the fix, there are 275 tests collected (matches current CI runs on GHA):

```
 $  uv run pytest --collect-only
================================ test session starts =================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/kyle/repos/rst2pdf
configfile: pyproject.toml
plugins: xdist-3.6.1
collected 275 items

...

============================ 275 tests collected in 0.13s ============================
```

After the fix, there are 315 tests collected (all of those starting with `sphinx`):

```
 $  uv run pytest --collect-only
================================ test session starts =================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/kyle/repos/rst2pdf
configfile: pyproject.toml
plugins: xdist-3.6.1
collected 315 items

...

============================ 315 tests collected in 0.13s ============================
```

Bug appeared to be accidentally introduced in 3ad61be8d