### PR TITLE
Remove smartypants, use the docutils version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "pygments~=2.0",
     "pyyaml~=6.0",
     "reportlab~=4.0",
-    "smartypants~=2.0",
 ]
 description = "Convert reStructured Text to PDF via ReportLab."
 dynamic = ["version"]

--- a/rst2pdf/basenodehandler.py
+++ b/rst2pdf/basenodehandler.py
@@ -35,8 +35,8 @@ from copy import copy
 import inspect
 import types
 
-from smartypants import smartypants
 import docutils.nodes
+from docutils.utils import smartquotes
 
 from .flowables import BoundByWidth, TocEntry
 from .log import log, nodeid
@@ -290,14 +290,14 @@ class NodeHandler(metaclass=MetaHelper):
     def get_text(self, client, node, replaceEnt):
         return client.gather_pdftext(node)
 
-    def apply_smartypants(self, text, smarty, node):
-        # Try to be clever about when to use smartypants
+    def apply_replacements(self, text, smarty, node):
+        # Try to be clever about when to replace characters
         if node.__class__ in (
             docutils.nodes.paragraph,
             docutils.nodes.block_quote,
             docutils.nodes.title,
         ):
-            return smartypants(text, smarty)
+            return smartquotes.smartyPants(text, smarty)
         return text
 
     # End overridable attributes and methods for textdispatch
@@ -313,6 +313,6 @@ class NodeHandler(metaclass=MetaHelper):
         except UnicodeDecodeError:
             pass
 
-        text = self.apply_smartypants(text, client.smartypants_attributes, node)
+        text = self.apply_replacements(text, client.smartypants_attributes, node)
         node.pdftext = text
         return text

--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -55,6 +55,7 @@ from docutils.parsers.rst import directives
 from docutils.readers import standalone
 from docutils.transforms import Transform
 from docutils.utils import DependencyList
+from docutils.utils import smartquotes
 
 try:
     from roman import toRoman
@@ -102,7 +103,6 @@ from rst2pdf.flowables import (
 from rst2pdf.sinker import Sinker
 from rst2pdf.image import MyImage, missing
 from rst2pdf.log import log, nodeid
-from smartypants import smartypants
 from rst2pdf import styles as sty
 from rst2pdf.nodehandlers import nodehandlers
 from rst2pdf.languages import get_language_available
@@ -213,14 +213,7 @@ class RstToPdf(object):
         self.background_fit_mode = background_fit_mode
         self.to_unlink = []
 
-        # See https://pythonhosted.org/smartypants/reference.html#smartypants-module
-        self.smartypants_attributes = 0
-        if smarty == '1':
-            self.smartypants_attributes = 1 | 6 | 8 | 64 | 512
-        elif smarty == '2':
-            self.smartypants_attributes = 1 | 6 | 24 | 64 | 512
-        elif smarty == '3':
-            self.smartypants_attributes = 1 | 6 | 40 | 64 | 512
+        self.smartypants_attributes = smarty
 
         self.baseurl = baseurl
         self.repeat_table_rows = repeat_table_rows
@@ -1008,7 +1001,7 @@ class HeaderOrFooter(object):
             text = text.replace(u"###Title###", doc.title)
             text = text.replace(u"###Section###", getattr(canv, 'sectName', ''))
             text = text.replace(u"###SectNum###", getattr(canv, 'sectNum', ''))
-            text = smartypants(text, smarty)
+            text = smartquotes.smartyPants(text, smarty)
             return text
 
         for i, e in enumerate(elems):

--- a/tests/input/sphinx-smartquotes/index.rst
+++ b/tests/input/sphinx-smartquotes/index.rst
@@ -3,12 +3,15 @@ rst2pdf Sphinx pdf_smartquotes test
 
 This test ensures that the ``pdf_smartquotes`` config option works.
 
-A -- B
+A -- B has an en-dash between A and B
 
-A --- B
+A --- B has an em-dash between A and B
 
-"A B"
+"A B" has curly quotes around A and B
 
-A ... B
+\`\`A B'' has curly quotes around A and B
 
-\`\`A B''
+A ... B has an elipsis between A and B
+
+A . . . B has an elipsis between A and B
+

--- a/tests/input/sphinx-smartquotes/index.rst
+++ b/tests/input/sphinx-smartquotes/index.rst
@@ -7,7 +7,9 @@ A -- B has an en-dash between A and B
 
 A --- B has an em-dash between A and B
 
-"A B" has curly quotes around A and B
+"A B" has curly double quotes around A and B
+
+'A B' has curly single quotes around A and B
 
 \`\`A B'' has curly quotes around A and B
 

--- a/tests/input/test_smarty.rst
+++ b/tests/input/test_smarty.rst
@@ -1,9 +1,12 @@
-A -- B
+A -- B has an en-dash between A and B
 
-A --- B
+A --- B has an em-dash between A and B
 
-"A B"
+"A B" has curly quotes around A and B
 
-A ... B
+\`\`A B'' has curly quotes around A and B
 
-\`\`A B''
+A ... B has an elipsis between A and B
+
+A . . . B has an elipsis between A and B
+

--- a/tests/input/test_smarty.rst
+++ b/tests/input/test_smarty.rst
@@ -2,7 +2,9 @@ A -- B has an en-dash between A and B
 
 A --- B has an em-dash between A and B
 
-"A B" has curly quotes around A and B
+"A B" has curly double quotes around A and B
+
+'A B' has curly single quotes around A and B
 
 \`\`A B'' has curly quotes around A and B
 

--- a/tests/reference/sphinx-smartquotes.pdf
+++ b/tests/reference/sphinx-smartquotes.pdf
@@ -58,7 +58,7 @@ endobj
 endobj
 11 0 obj
 <<
-/Length 1242
+/Length 1391
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -98,25 +98,32 @@ q
 1 0 0 1 40.01575 703.0394 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224 has curly quotes around A and B) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224 has curly double quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 40.01575 685.0394 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\222\222 has curly quotes around A and B) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\221A B\222 has curly single quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 40.01575 667.0394 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\222\222 has curly quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 40.01575 649.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 631.0394 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
@@ -149,8 +156,8 @@ xref
 0000001085 00000 n 
 0000001206 00000 n 
 0000001266 00000 n 
-0000002560 00000 n 
-0000002601 00000 n 
+0000002709 00000 n 
+0000002750 00000 n 
 trailer
 <<
 /ID 
@@ -162,5 +169,5 @@ trailer
 /Size 14
 >>
 startxref
-2635
+2784
 %%EOF

--- a/tests/reference/sphinx-smartquotes.pdf
+++ b/tests/reference/sphinx-smartquotes.pdf
@@ -58,7 +58,7 @@ endobj
 endobj
 11 0 obj
 <<
-/Length 970
+/Length 1242
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -84,34 +84,42 @@ q
 1 0 0 1 40.01575 739.0394 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \226 B) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \226 B has an en-dash between A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 40.01575 721.0394 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \227 B) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \227 B has an em-dash between A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 40.01575 703.0394 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224 has curly quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 40.01575 685.0394 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\222\222 has curly quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 40.01575 667.0394 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (\221) Tj (\221) Tj (A B\222\222) Tj T* ET
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
+Q
+Q
+q
+1 0 0 1 40.01575 649.0394 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
 Q
 Q
  
@@ -141,8 +149,8 @@ xref
 0000001085 00000 n 
 0000001206 00000 n 
 0000001266 00000 n 
-0000002287 00000 n 
-0000002328 00000 n 
+0000002560 00000 n 
+0000002601 00000 n 
 trailer
 <<
 /ID 
@@ -154,5 +162,5 @@ trailer
 /Size 14
 >>
 startxref
-2362
+2635
 %%EOF

--- a/tests/reference/test_smarty.pdf
+++ b/tests/reference/test_smarty.pdf
@@ -38,38 +38,50 @@ endobj
 endobj
 7 0 obj
 <<
-/Length 592
+/Length 836
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
 q
 1 0 0 1 57.02362 753.0236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (A \226 B) Tj T* ET
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \226 B has an en-dash between A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 57.02362 735.0236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (A \227 B) Tj T* ET
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \227 B has an em-dash between A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 57.02362 717.0236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (\223) Tj (A B) Tj (\224) Tj T* ET
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224 has curly quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 57.02362 699.0236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (A \205 B) Tj T* ET
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224 has curly quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 57.02362 681.0236 cm
 q
-BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (\221) Tj (\221) Tj (A B) Tj (\222) Tj (\222) Tj T* ET
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 663.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
 Q
 Q
  
@@ -95,8 +107,8 @@ xref
 0000000500 00000 n 
 0000000757 00000 n 
 0000000816 00000 n 
-0000001458 00000 n 
-0000001497 00000 n 
+0000001702 00000 n 
+0000001741 00000 n 
 trailer
 <<
 /ID 
@@ -108,5 +120,5 @@ trailer
 /Size 10
 >>
 startxref
-1530
+1774
 %%EOF

--- a/tests/reference/test_smarty.pdf
+++ b/tests/reference/test_smarty.pdf
@@ -38,7 +38,7 @@ endobj
 endobj
 7 0 obj
 <<
-/Length 836
+/Length 985
 >>
 stream
 1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
@@ -60,25 +60,32 @@ q
 1 0 0 1 57.02362 717.0236 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224 has curly quotes around A and B) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224 has curly double quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 57.02362 699.0236 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224 has curly quotes around A and B) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\221A B\222 has curly single quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 57.02362 681.0236 cm
 q
 0 0 0 rg
-BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (\223A B\224 has curly quotes around A and B) Tj T* ET
 Q
 Q
 q
 1 0 0 1 57.02362 663.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 645.0236 cm
 q
 0 0 0 rg
 BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A \205 B has an elipsis between A and B) Tj T* ET
@@ -107,8 +114,8 @@ xref
 0000000500 00000 n 
 0000000757 00000 n 
 0000000816 00000 n 
-0000001702 00000 n 
-0000001741 00000 n 
+0000001851 00000 n 
+0000001890 00000 n 
 trailer
 <<
 /ID 
@@ -120,5 +127,5 @@ trailer
 /Size 10
 >>
 startxref
-1774
+1923
 %%EOF

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -1423,7 +1423,6 @@ dependencies = [
     { name = "pygments" },
     { name = "pyyaml" },
     { name = "reportlab" },
-    { name = "smartypants" },
 ]
 
 [package.optional-dependencies]
@@ -1466,7 +1465,6 @@ requires-dist = [
     { name = "pygments", specifier = "~=2.0" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "reportlab", specifier = "~=4.0" },
-    { name = "smartypants", specifier = "~=2.0" },
     { name = "sphinx", marker = "extra == 'sphinx'", specifier = ">7.3" },
     { name = "svglib", marker = "extra == 'svgsupport'" },
     { name = "xhtml2pdf", marker = "extra == 'rawhtmlsupport'" },
@@ -1487,14 +1485,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
-]
-
-[[package]]
-name = "smartypants"
-version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/ed/1da76d11aa858ee23dac5b52d9ac2db7df02b89f7679d5d8970bcd44b59c/smartypants-2.0.1-py2.py3-none-any.whl", hash = "sha256:8db97f7cbdf08d15b158a86037cd9e116b4cf37703d24e0419a0d64ca5808f0d", size = 9875 },
 ]
 
 [[package]]
@@ -1675,7 +1665,7 @@ name = "tzlocal"
 version = "5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e", size = 30201 }
 wheels = [


### PR DESCRIPTION
Fixes #1244 where we depend on smartypants but it's no longer actively maintained and has problems with newer versions of Python.

Looks like Sphinx or docutils ran into this and wrote the replacement function we need (I love open source) but something funky is going on - the same configuration options are supported as in our manual, but the output isn't quite right and two of the tests fail so I need to take another look before we can properly review//merge.