### PR TITLE
Add section for setuptools_scm in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,10 @@ exclude = '''
 [tool.setuptools]
 packages = ["rst2pdf"]
 
+[tool.setuptools_scm]
+# Presence of the [tool.setuptools_scm] table enables setuptools-scm
+
+
 [dependency-groups]
 dev = [
     "flake8>=5.0.4",


### PR DESCRIPTION
As per https://setuptools-scm.readthedocs.io/en/latest/usage/, we need the `[tool.setuptools_scm]` table in `pyproject.toml` to enable setuptools-scm.
