### PR TITLE
Support dynamic versions for releasing with uv

### DIFF
--- a/doc/RELEASE_PROCESS.rst
+++ b/doc/RELEASE_PROCESS.rst
@@ -15,28 +15,36 @@ This is an outline of what needs to be done in order to release rst2pdf.
 
       $ git checkout main
 
-#. Use changelog-generator_ (or similar) to create a changelog
+#. Use changelog-generator_ (or similar) to create a changelog for the tag's message
 
    ::
 
-      $ changelog-generator -u rst2pdf -r rst2pdf -m 999
+      $ changelog-generator -u rst2pdf -r rst2pdf -m {id of milestone}
 
 #. Tag release with version number e.g.
 
    ::
 
-      $ git tag -s 0.94
-      $ git push upstream 0.94
+      $ git tag -s 0.103
+
+#. Update the uv.lock file with the correct version number, move the tag and push
+
+      $ uv lock
+      $ git add uv.lock
+      $ git commit -m "Update uv.lock for version 0.103"
+      $ git tag -s 0.103 -f
+      $ git push upstream 0.103
 
 #. Build manual
 
-   Check out the tag first and then install via ``uv``. We do this so that the version number that
+   Check out the tag first if it's not already checked out from the previous step.
+   Install via ``uv``. We do this so that the version number that
    is rendered to the first page of the PDF is displayed as "{version number} (final)" rather than
    as a dev version.
 
    ::
 
-     $ git checkout 0.94
+     $ git checkout 0.103
      $ uv sync --all-extras
 
    Generate the HTML and PDF docs:
@@ -50,7 +58,7 @@ This is an outline of what needs to be done in order to release rst2pdf.
 
    ::
 
-     $ exiftool -PDF:Subject="v0.94 r2019011700" doc/output/pdf/manual.pdf
+     $ exiftool -PDF:Subject="v0.103 r2019011700" doc/output/pdf/manual.pdf
      $ exiftool -PDF:Author="rst2pdf project; Roberto Alsina" doc/output/pdf/manual.pdf
 
    and upload to HTML and PDF to the website
@@ -94,7 +102,7 @@ This is an outline of what needs to be done in order to release rst2pdf.
     ::
 
        $ uvx -n --index-url https://test.pypi.org/simple --extra-index-url https://pypi.org/simple --prerelease allow \
-         --index-strategy unsafe-best-match rst2pdf@0.101rc1 tests/input/test_tableofcontents.rst
+         --index-strategy unsafe-best-match rst2pdf@0.103rc1 tests/input/test_tableofcontents.rst
 
 #. Delete the build artifacts and dist files with:
 

--- a/doc/RELEASE_PROCESS.rst
+++ b/doc/RELEASE_PROCESS.rst
@@ -37,8 +37,7 @@ This is an outline of what needs to be done in order to release rst2pdf.
 
 #. Build manual
 
-   Check out the tag first if it's not already checked out from the previous step.
-   Install via ``uv``. We do this so that the version number that
+   Check out the tag first and then install via ``uv``. We do this so that the version number that
    is rendered to the first page of the PDF is displayed as "{version number} (final)" rather than
    as a dev version.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ Releases = "https://github.com/rst2pdf/rst2pdf/releases"
 Source = "https://github.com/rst2pdf/rst2pdf"
 "Bug Reports" = "https://github.com/rst2pdf/rst2pdf/issues"
 
+[tool.uv]
+cache-keys = [{ git = { commit = true, tags = true } }]
+
 [tool.black]
 line-length = 88
 target-version = ['py36']


### PR DESCRIPTION
To ensure that the correct version number is applied when building for release and also on the manual's cover page, we have to do some work with uv. 

This is because uv stores the version number of rst2pdf in uv.lock itself. To get the version number in the lock file to match the tag we need to:

1. Checkout a clean `main`
2. Create a tag
3. Run `uv lock`
4. As this has updated the `uv.lock` file, we need to commit this changed file
5. Move the tag to the new commit so that uv.lock's version matches the tag.
6. Push `main` and the tag to GitHub

There's a minor problem here in that the person doing this work needs the right to push to main, so I imagine we'll need to revisit this at some point. Maybe when we automate it!

This PR:
1. Updates pyproject.toml to so that `uv` will rebuild when the git commit or tag changes. See https://docs.astral.sh/uv/concepts/cache/#dynamic-metadata.
2. Updates RELEASE_PROCESS.rst to include the additional information
