### PR TITLE
Workaround pypa/setuptools#4759

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,10 @@ exclude = '''
 
 [tool.setuptools]
 packages = ["rst2pdf"]
+ # FIXME: this is a workaround; see:
+ #   - https://github.com/astral-sh/uv/issues/9513
+ #   - https://github.com/pypa/setuptools/issues/4759
+ license-files = []
 
 [tool.setuptools_scm]
 # Presence of the [tool.setuptools_scm] table enables setuptools-scm


### PR DESCRIPTION
Set license-files to an empty array to work around issues releasing to PyPI. See:

- https://github.com/astral-sh/uv/issues/9513
- https://github.com/pypa/setuptools/issues/4759
