### PR TITLE
Add codeowners to tag reviewers on every PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @akrabat @lornajane


### PR DESCRIPTION
We don't have reviewers by default (although the maintainers are subscribed to notifications). Adding ourselves as codeowners so we'll get tagged for review.