### PR TITLE
drop usage of old importlib_metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 ]
 dependencies = [
     "docutils~=0.21.2",
-    "importlib-metadata~=8.0",
     "jinja2~=3.0",
     "packaging~=25.0",
     "pygments~=2.0",

--- a/rst2pdf/__init__.py
+++ b/rst2pdf/__init__.py
@@ -1,10 +1,8 @@
 # See LICENSE.txt for licensing terms
 
-# TODO(stephenfin): Switch to 'importlib.metadata' once we drop support for
-# Python < 3.8
-import importlib_metadata
+import importlib.metadata
 
 try:
-    version = importlib_metadata.version('rst2pdf')
-except importlib_metadata.PackageNotFoundError:
+    version = importlib.metadata.version('rst2pdf')
+except importlib.metadata.PackageNotFoundError:
     version = None

--- a/rst2pdf/roles/package.py
+++ b/rst2pdf/roles/package.py
@@ -2,17 +2,15 @@
 
 from docutils import nodes
 from docutils.parsers.rst import roles
-import importlib_metadata
+import importlib.metadata
 import packaging.version
 
 
 def _get_version(package):
     """Get version from the usual methods."""
-    # TODO(stephenfin): Switch to 'importlib.metadata' once we drop support for
-    # Python < 3.8
     try:
-        parsed_version = packaging.version.parse(importlib_metadata.version(package))
-    except importlib_metadata.PackageNotFoundError:
+        parsed_version = packaging.version.parse(importlib.metadata.version(package))
+    except importlib.metadata.PackageNotFoundError:
         return 'UNKNOWN', 'UNKNOWN'
 
     version = '.'.join(str(r) for r in parsed_version.release)


### PR DESCRIPTION
I think that importlib_metadata could be removed from Debian before end of 2025, let's see how it fares.