### PR TITLE
Link to the HTML manual

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Features
 
 * `Sphinx <https://www.sphinx-doc.org>`_ integration
 
-* `Full user's manual <https://rst2pdf.org/static/manual.pdf>`_
+* `Full user's manual <https://rst2pdf.org/manual.html>`_
 
 Installation
 ------------


### PR DESCRIPTION
The other location was dead. Although rst2pdf.org points to a new PDF file (https://rst2pdf.org/_downloads/cb7dadec71e04885ee6e55dec4d89d6d/manual.pdf), that one seems empty.

The HTML one linked from the home page works.