### PR TITLE
Fix keepWithNext when a document is built more than once

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,11 @@
 
+{next}
+------
+
+* Fixed: ``keepWithNext`` is now honoured when the document is built more than once (such as when
+  a header or footer contains ``###Total###``). (PR #1310)
+
+
 0.105 (2026-01-09)
 ------------------
 * Changed: We have updated our dependencies to support the latest version of packaging (v)26 and pytest (v9)

--- a/rst2pdf/createpdf.py
+++ b/rst2pdf/createpdf.py
@@ -696,10 +696,26 @@ class RstToPdf(object):
             if not isinstance(elements[-1], UnhappyOnce):
                 log.info('Forcing second pass so Total pages work')
                 elements.append(UnhappyOnce())
+
+        # Store keepWithNext as ReportLab clears them when building, so we can
+        # restore before a rebuild (e.g. when ###Total### is in the footer)
+        keep_with_next = [
+            (e, e.__dict__['keepWithNext'])
+            for e in elements
+            if 'keepWithNext' in e.__dict__
+        ]
+
         while True:
             try:
                 log.info("Starting build")
                 self.elements = elements
+
+                # Restore keepWithNext on every element that it was set on
+                for e in elements:
+                    e.__dict__.pop('keepWithNext', None)
+                for e, value in keep_with_next:
+                    e.keepWithNext = value
+
                 # See if this *must* be multipass
                 pdfdoc.multiBuild(elements)
                 # Force a multibuild pass

--- a/tests/input/test_keep_with_next_total.rst
+++ b/tests/input/test_keep_with_next_total.rst
@@ -1,0 +1,24 @@
+.. footer:: Page ###Page### of ###Total###
+
+Keep with next across multiple builds
+======================================
+
+Setting ``###Total###`` in the footer causes a second build pass which caused
+headings to lose their ``keepWithNext`` setting, resulting in headings
+stranded at the bottom of a page.
+
+This test passes if the PDF has two pages and the "Second section" title
+is at the top of page 2 and not at the bottom of page 1.
+
+.. raw:: pdf
+
+   Spacer 0 19.5cm
+
+
+This should be the last line of page 1.
+
+
+Second section
+==============
+
+This paragraph forces the "Second section" title to render on page two.

--- a/tests/reference/test_keep_with_next_total.pdf
+++ b/tests/reference/test_keep_with_next_total.pdf
@@ -1,0 +1,198 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 13 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 14 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Outlines 9 0 R /PageLabels 15 0 R /PageMode /UseNone /Pages 12 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author () /CreationDate (D:20000101000000+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title () /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 2 /First 10 0 R /Last 11 0 R /Type /Outlines
+>>
+endobj
+10 0 obj
+<<
+/Dest [ 5 0 R /XYZ 57.02362 765.0236 0 ] /Next 11 0 R /Parent 9 0 R /Title (Keep with next across multiple builds)
+>>
+endobj
+11 0 obj
+<<
+/Dest [ 6 0 R /XYZ 57.02362 765.0236 0 ] /Parent 9 0 R /Prev 10 0 R /Title (Second section)
+>>
+endobj
+12 0 obj
+<<
+/Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+13 0 obj
+<<
+/Length 1087
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (Keep with next across multiple builds) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 714.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 2.594556 Tw 12 TL /F1 10 Tf 0 0 0 rg (Setting ) Tj /F3 10 Tf (###Total###) Tj /F1 10 Tf ( in the footer causes a second build pass which caused headings to lose their) Tj T* 0 Tw /F3 10 Tf (keepWithNext) Tj /F1 10 Tf ( setting, resulting in headings stranded at the bottom of a page.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL -0.047986 Tw (This test passes if the PDF has two pages and the "Second section" title is at the top of page 2 and not at the) Tj T* 0 Tw (bottom of page 1.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 131.2677 cm
+Q
+q
+1 0 0 1 57.02362 113.2677 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This should be the last line of page 1.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 221.0392 0 Td (Page 1 of 2) Tj T* -221.0392 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+14 0 obj
+<<
+/Length 498
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (Second section) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 726.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This paragraph forces the "Second section" title to render on page two.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 726.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 221.0392 0 Td (Page 2 of 2) Tj T* -221.0392 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+15 0 obj
+<<
+/Nums [ 0 16 0 R 1 17 0 R ]
+>>
+endobj
+16 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+17 0 obj
+<<
+/S /D /St 2
+>>
+endobj
+xref
+0 18
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000340 00000 n 
+0000000445 00000 n 
+0000000650 00000 n 
+0000000855 00000 n 
+0000000959 00000 n 
+0000001216 00000 n 
+0000001289 00000 n 
+0000001426 00000 n 
+0000001540 00000 n 
+0000001606 00000 n 
+0000002745 00000 n 
+0000003294 00000 n 
+0000003344 00000 n 
+0000003378 00000 n 
+trailer
+<<
+/ID 
+[<2db82f8d13fc9aad0f6ac8c1445975f3><2db82f8d13fc9aad0f6ac8c1445975f3>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 18
+>>
+startxref
+3412
+%%EOF


### PR DESCRIPTION
When a header or footer contains `###Total###`, the document is built a second time which can result in headings stranded at the bottom of the page because ReportLab has cleared the `keepWithNext` setting.

This MR fixes this problem by storing the original `keepWithNext` setting and then restoring it before each rebuild.

Fixes #1309 
Related to #963